### PR TITLE
Adaptation for IAM in nodes, the ability to set root disk size

### DIFF
--- a/genesis_core/node/constants.py
+++ b/genesis_core/node/constants.py
@@ -19,6 +19,7 @@ import typing as tp
 
 DEF_SQL_LIMIT = 300
 EP_MACHINE_POOL_DRIVERS = "gcn_machine_pool_driver"
+DEF_ROOT_DISK_SIZE = 15
 
 BootType = tp.Literal["hd", "network", "cdrom"]
 

--- a/genesis_core/node/machine/pool/driver/exceptions.py
+++ b/genesis_core/node/machine/pool/driver/exceptions.py
@@ -13,13 +13,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-from __future__ import annotations
 
-from restalchemy.dm import relationships
-
-from genesis_core.node.dm import models
+import uuid as sys_uuid
+from genesis_core.common import exceptions
 
 
-class Machine(models.Machine):
-    node = relationships.relationship(models.Node)
-    pool = relationships.relationship(models.MachinePool)
+class MachineAlreadyExistsError(exceptions.GCException):
+    __template__ = "The machine {machine} already exists."
+    machine: sys_uuid.UUID
+
+
+class VolumeAlreadyExistsError(exceptions.GCException):
+    __template__ = "The volume {volume} already exists."
+    volume: sys_uuid.UUID

--- a/genesis_core/node/machine/pool/driver/libvirt.py
+++ b/genesis_core/node/machine/pool/driver/libvirt.py
@@ -554,6 +554,8 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
                 domain.destroy()
             except libvirt.libvirtError:
                 LOG.debug("The domain is not in the running state")
+            # FIXME(akremenetsky): Actully we should undefine the
+            # domain before volume deletion
             domain.undefine()
 
         if delete_volumes:

--- a/genesis_core/orch_api/api/controllers.py
+++ b/genesis_core/orch_api/api/controllers.py
@@ -15,6 +15,12 @@
 #    under the License.
 
 from restalchemy.api import controllers
+from restalchemy.api import resources
+from restalchemy.storage import exceptions as ra_storage_exceptions
+
+from genesis_core.node import constants as nc
+from genesis_core.orch_api.dm import models as node_models
+from genesis_core.orch_api.api import packers
 
 
 class ApiEndpointController(controllers.RoutesListController):
@@ -29,3 +35,49 @@ class HealthController(controllers.Controller):
 
     def filter(self, filters):
         return "OK"
+
+
+class NodesController(controllers.BaseResourceController):
+    """Controller for /v1/nodes/ endpoint"""
+
+    __resource__ = resources.ResourceByRAModel(
+        model_class=node_models.Node,
+        process_filters=True,
+        convert_underscore=False,
+    )
+
+
+class MachinesController(controllers.BaseResourceController):
+    """Controller for /v1/machines/ endpoint"""
+
+    __resource__ = resources.ResourceByRAModel(
+        model_class=node_models.Machine,
+        process_filters=True,
+        convert_underscore=False,
+    )
+
+
+class NetBootController(controllers.BaseResourceController):
+    """Controller for /v1/boots/ endpoint"""
+
+    __resource__ = resources.ResourceByRAModel(
+        model_class=node_models.Netboot,
+        process_filters=True,
+        convert_underscore=False,
+    )
+
+    __packer__ = packers.IPXEPacker
+
+    def get(self, uuid, **kwargs):
+        try:
+            netboot = super().get(uuid, **kwargs)
+        except ra_storage_exceptions.RecordNotFound:
+            # Generate a dummy netboot object for netboot
+            # configuration. Network is default option
+            # for such machines.
+            netboot = node_models.Netboot(
+                uuid=uuid,
+                boot=nc.BootAlternative.network.value,
+            )
+
+        return netboot, 200, {"Content-Type": "application/octet-stream"}

--- a/genesis_core/orch_api/api/packers.py
+++ b/genesis_core/orch_api/api/packers.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from restalchemy.api import packers
 
 from genesis_core.node import constants as nc
-from genesis_core.node.machine.dm import models
+from genesis_core.orch_api.dm import models
 
 
 _from_net_template = """#!ipxe

--- a/genesis_core/orch_api/api/routes.py
+++ b/genesis_core/orch_api/api/routes.py
@@ -26,6 +26,25 @@ class HealthRoute(routes.Route):
     __allow_methods__ = [routes.FILTER]
 
 
+class NetbootRoute(routes.Route):
+    """Handler for /v1/boots/ endpoint"""
+
+    __controller__ = controllers.NetBootController
+    __allow_methods__ = [routes.GET]
+
+
+class NodeRoute(routes.Route):
+    """Handler for /v1/nodes/ endpoint"""
+
+    __controller__ = controllers.NodesController
+
+
+class MachineRoute(routes.Route):
+    """Handler for /v1/machines/ endpoint"""
+
+    __controller__ = controllers.MachinesController
+
+
 class ApiEndpointRoute(routes.Route):
     """Handler for /v1/ endpoint"""
 
@@ -33,3 +52,6 @@ class ApiEndpointRoute(routes.Route):
     __allow_methods__ = [routes.FILTER]
 
     health = routes.route(HealthRoute)
+    boots = routes.route(NetbootRoute)
+    nodes = routes.route(NodeRoute)
+    machines = routes.route(MachineRoute)

--- a/genesis_core/orch_api/dm/models.py
+++ b/genesis_core/orch_api/dm/models.py
@@ -1,0 +1,56 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+from restalchemy.dm import types
+
+from genesis_core.node.dm import models as node_models
+
+# TODO(akremenetsky): Remove these default values
+# after support of multiple stands
+GC_HOST = "10.20.0.2"
+GC_PORT = 11011
+
+
+class Netboot(node_models.Netboot):
+    __custom_properties__ = {
+        "gc_host": types.String(max_length=255),
+        "gc_port": types.Integer(),
+    }
+
+    def __init__(
+        self, gc_host: str = GC_HOST, gc_port: int = GC_PORT, *args, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.gc_host = gc_host
+        self.gc_port = gc_port
+
+    @classmethod
+    def restore_from_storage(
+        cls, gc_host: str = GC_HOST, gc_port: int = GC_PORT, **kwargs
+    ):
+        obj = super().restore_from_storage(**kwargs)
+        obj.gc_host = gc_host
+        obj.gc_port = gc_port
+        return obj
+
+
+class Node(node_models.Node):
+    pass
+
+
+class Machine(node_models.Machine):
+    pass

--- a/genesis_core/tests/functional/conftest.py
+++ b/genesis_core/tests/functional/conftest.py
@@ -31,14 +31,18 @@ from genesis_core.user_api.api import app as user_app
 from genesis_core.tests.functional import utils as test_utils
 
 
+FIRST_MIGRATION = "0000-init-compute-tables-0234eb"
+LAST_MIGRATION = "0002-add-volumes-tables-a6972c"
+
+
 @pytest.fixture(scope="module")
-def user_api():
-    class UserApiRestService(test_utils.RestServiceTestCase):
-        __FIRST_MIGRATION__ = "0000-init-compute-tables-0234eb"
-        __LAST_MIGRATION__ = "0000-init-compute-tables-0234eb"
+def user_api_service():
+    class ApiRestService(test_utils.RestServiceTestCase):
+        __FIRST_MIGRATION__ = FIRST_MIGRATION
+        __LAST_MIGRATION__ = LAST_MIGRATION
         __APP__ = user_app.get_api_application()
 
-    rest_service = UserApiRestService()
+    rest_service = ApiRestService()
     rest_service.setup_class()
 
     yield rest_service
@@ -46,13 +50,13 @@ def user_api():
     rest_service.teardown_class()
 
 
-@pytest.fixture(autouse=True)
-def user_api_with_migration(user_api: test_utils.RestServiceTestCase):
-    user_api.setup_method()
+@pytest.fixture()
+def user_api(user_api_service: test_utils.RestServiceTestCase):
+    user_api_service.setup_method()
 
-    yield user_api
+    yield user_api_service
 
-    user_api.teardown_method()
+    user_api_service.teardown_method()
 
 
 @pytest.fixture

--- a/genesis_core/tests/functional/restapi/test_node_orch_api.py
+++ b/genesis_core/tests/functional/restapi/test_node_orch_api.py
@@ -1,0 +1,94 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import typing as tp
+import uuid as sys_uuid
+from urllib.parse import urljoin
+
+import pytest
+import requests
+
+from genesis_core.node.dm import models
+from genesis_core.tests.functional import utils as test_utils
+from genesis_core.tests.functional import conftest
+from genesis_core.orch_api.api import app as orch_app
+
+
+class TestNodeOrchApi:
+    @pytest.fixture(scope="class")
+    def orch_api_service(self):
+        class ApiRestService(test_utils.RestServiceTestCase):
+            __FIRST_MIGRATION__ = conftest.FIRST_MIGRATION
+            __LAST_MIGRATION__ = conftest.LAST_MIGRATION
+            __APP__ = orch_app.get_api_application()
+
+        rest_service = ApiRestService()
+        rest_service.setup_class()
+
+        yield rest_service
+
+        rest_service.teardown_class()
+
+    @pytest.fixture()
+    def orch_api(self, orch_api_service: test_utils.RestServiceTestCase):
+        orch_api_service.setup_method()
+
+        yield orch_api_service
+
+        orch_api_service.teardown_method()
+
+    def test_netboots_default_net(
+        self, orch_api: test_utils.RestServiceTestCase
+    ):
+        uuid = sys_uuid.uuid4()
+        url = urljoin(orch_api.base_url, f"boots/{str(uuid)}")
+
+        response = requests.get(url)
+
+        assert response.status_code == 200
+        assert response.text.startswith("#!ipxe")
+        assert "initrd" in response.text
+        assert "vmlinuz" in response.text
+        assert "gc_base_url" in response.text
+
+    def test_netboots_hd_boot(
+        self,
+        machine_factory: tp.Callable,
+        default_pool: tp.Dict[str, tp.Any],
+        orch_api: test_utils.RestServiceTestCase,
+    ):
+        uuid = sys_uuid.uuid4()
+        machine = machine_factory(
+            boot="hd0",
+            uuid=uuid,
+            firmware_uuid=uuid,
+            pool=sys_uuid.UUID(default_pool["uuid"]),
+        )
+        pool = models.MachinePool.restore_from_simple_view(**default_pool)
+        pool.insert()
+
+        machine = models.Machine.restore_from_simple_view(**machine)
+        machine.insert()
+
+        url = urljoin(orch_api.base_url, f"boots/{machine.uuid}")
+
+        response = requests.get(url)
+
+        assert response.status_code == 200
+        assert response.text.startswith("#!ipxe")
+        assert "initrd" not in response.text
+        assert "vmlinuz" not in response.text
+        assert "0x80" in response.text

--- a/genesis_core/tests/functional/service/test_scheduler.py
+++ b/genesis_core/tests/functional/service/test_scheduler.py
@@ -29,7 +29,7 @@ class TestSchedulerService:
     def teardown_method(self) -> None:
         pass
 
-    def test_nothing_scheduler(self):
+    def test_nothing_scheduler(self, default_pool: tp.Dict[str, tp.Any]):
         self._service._iteration()
 
     def test_schedule_pool(
@@ -55,6 +55,10 @@ class TestSchedulerService:
     ):
         self._service._iteration()
         machines = models.Machine.objects.get_all()
+        volumes = models.MachineVolume.objects.get_all()
 
         assert len(machines) == 1
+        assert len(volumes) == 1
         assert str(machines[0].node) == default_node["uuid"]
+        assert str(volumes[0].node) == default_node["uuid"]
+        assert volumes[0].machine == machines[0].uuid

--- a/genesis_core/user_api/api/controllers.py
+++ b/genesis_core/user_api/api/controllers.py
@@ -16,12 +16,9 @@
 
 from restalchemy.api import controllers
 from restalchemy.api import resources
-from restalchemy.storage import exceptions as ra_storage_exceptions
 
 from genesis_core.node import constants as nc
 from genesis_core.node.dm import models as node_models
-from genesis_core.node.machine.dm import models as machine_models
-from genesis_core.user_api.api import packers
 
 
 class ApiEndpointController(controllers.RoutesListController):
@@ -58,35 +55,6 @@ class MachinesController(controllers.BaseResourceController):
         process_filters=True,
         convert_underscore=False,
     )
-
-
-class NetBootController(controllers.BaseResourceController):
-    """Controller for /v1/boots/ endpoint"""
-
-    __resource__ = resources.ResourceByRAModel(
-        model_class=node_models.Netboot,
-        process_filters=True,
-        convert_underscore=False,
-    )
-
-    __packer__ = packers.IPXEPacker
-
-    def get(self, uuid, **kwargs):
-        try:
-            base_netboot: node_models.Netboot = super().get(uuid, **kwargs)
-            netboot = machine_models.Netboot.restore_from_simple_view(
-                **base_netboot.dump_to_simple_view()
-            )
-        except ra_storage_exceptions.RecordNotFound:
-            # Generate a dummy netboot object for netboot
-            # configuration. Network is default option
-            # for such machines.
-            netboot = machine_models.Netboot(
-                uuid=uuid,
-                boot=nc.BootAlternative.network.value,
-            )
-
-        return netboot, 200, {"Content-Type": "application/octet-stream"}
 
 
 class HypervisorsController(controllers.BaseResourceController):

--- a/genesis_core/user_api/api/routes.py
+++ b/genesis_core/user_api/api/routes.py
@@ -52,13 +52,6 @@ class MachineAgentRoute(routes.Route):
     __controller__ = controllers.MachineAgentController
 
 
-class NetbootRoute(routes.Route):
-    """Handler for /v1/boots/ endpoint"""
-
-    __controller__ = controllers.NetBootController
-    __allow_methods__ = [routes.GET]
-
-
 class ApiEndpointRoute(routes.Route):
     """Handler for /v1/ endpoint"""
 
@@ -71,4 +64,3 @@ class ApiEndpointRoute(routes.Route):
     machines = routes.route(MachineRoute)
     hypervisors = routes.route(HypervisorRoute)
     machine_agents = routes.route(MachineAgentRoute)
-    boots = routes.route(NetbootRoute)

--- a/migrations/0000-init-compute-tables-0234eb.py
+++ b/migrations/0000-init-compute-tables-0234eb.py
@@ -120,7 +120,6 @@ class MigrationStep(migrations.AbstarctMigrationStep):
         tables = [
             "machines",
             "nodes",
-            # "machine_pool_allocations",
             "machine_pools",
             "machine_agents",
         ]

--- a/migrations/0002-add-volumes-tables-a6972c.py
+++ b/migrations/0002-add-volumes-tables-a6972c.py
@@ -1,0 +1,115 @@
+# Copyright 2016 Eugene Frolov <eugene@frolov.net.ru>
+# Copyright 2025 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import migrations
+
+from genesis_core.node import constants as nc
+
+
+class MigrationStep(migrations.AbstarctMigrationStep):
+
+    def __init__(self):
+        self._depends = ["0001-init-all-tables-f47bad.py"]
+
+    @property
+    def migration_id(self):
+        return "a6972cd6-1cca-43a5-b8f7-47ead0af3eb9"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        sql_expressions = [
+            # TABLES
+            f"""
+            ALTER TABLE nodes 
+                ADD IF NOT EXISTS root_disk_size INTEGER NULL DEFAULT {nc.DEF_ROOT_DISK_SIZE};
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS node_volumes (
+                uuid UUID NOT NULL PRIMARY KEY,
+                project_id UUID NOT NULL,
+                name varchar(255) NOT NULL,
+                description varchar(255) NOT NULL,
+                node UUID references nodes(uuid) ON DELETE CASCADE,
+                size integer NOT NULL,
+                boot bool NOT NULL DEFAULT true,
+                label varchar(127) NULL,
+                device_type VARCHAR(16) NOT NULL CHECK (device_type IN ('QCOW2')),
+                created_at timestamp NOT NULL DEFAULT current_timestamp,
+                updated_at timestamp NOT NULL DEFAULT current_timestamp
+            );
+            """,
+            # VIEWS
+            """
+            CREATE OR REPLACE VIEW unscheduled_nodes AS
+                SELECT
+                    nodes.uuid,
+                    nodes.project_id,
+                    nodes.name,
+                    nodes.description,
+                    nodes.cores,
+                    nodes.ram,
+                    nodes.image,
+                    nodes.node_type,
+                    nodes.status,
+                    nodes.created_at,
+                    nodes.updated_at,
+                    nodes.root_disk_size
+                FROM nodes LEFT JOIN machines ON 
+                    nodes.uuid = machines.node WHERE machines.uuid is NULL;
+            """,
+            """
+            CREATE OR REPLACE VIEW machine_volumes AS
+                SELECT
+                    node_volumes.uuid,
+                    node_volumes.project_id,
+                    node_volumes.name,
+                    node_volumes.description,
+                    node_volumes.node,
+                    node_volumes.size,
+                    node_volumes.boot,
+                    node_volumes.label,
+                    node_volumes.device_type,
+                    machines.uuid as machine,
+                    node_volumes.created_at,
+                    node_volumes.updated_at
+                FROM node_volumes LEFT JOIN machines ON 
+                    node_volumes.node = machines.node;
+            """,
+        ]
+
+        for expr in sql_expressions:
+            session.execute(expr, None)
+
+    def downgrade(self, session):
+        tables = [
+            "node_volumes",
+        ]
+        views = [
+            "machine_volumes",
+        ]
+
+        for view_name in views:
+            self._delete_view_if_exists(session, view_name)
+
+        for table_name in tables:
+            self._delete_table_if_exists(session, table_name)
+
+
+migration_step = MigrationStep()


### PR DESCRIPTION
## Adaptation for IAM in nodes
Some API was moved under Orch API to exclude auth procedure. The Seed OS agent needs that. Added tests for Orch API

 ## Ability to specify root disk size
It's possible to specify root disk size (only **one disk**) now.  The `root_disk_size` field is used for this purpose. Look at the example below.

```shell
curl --location 'http://10.20.0.2:11010/v1/nodes/' \
--header 'Content-Type: application/json' \
--data '{
    "name": "genesis-test",
    "project_id": "780f7638-fd67-49ff-9786-08d8ab0af2ed",
    "root_disk_size": 20,
    "cores": 1,
    "ram": 1024,
    "image": "http://10.20.0.1:8080/genesis-devtools.raw"
}'
```