### PR TITLE
Base roles and permissions for nodes

### DIFF
--- a/genesis/genesis.yaml
+++ b/genesis/genesis.yaml
@@ -37,7 +37,7 @@ build:
         format: raw
         
         # OS profile for the image
-        profile: genesis_core
+        profile: genesis_base
 
         # Provisioning script
         script: images/install.sh

--- a/genesis/images/install.sh
+++ b/genesis/images/install.sh
@@ -24,6 +24,7 @@ GC_PATH="/opt/genesis_core"
 GC_CFG_DIR=/etc/genesis_core
 GC_ART_DIR="$GC_PATH/artifacts"
 VENV_PATH="$GC_PATH/.venv"
+BOOTSTRAP_PATH="/var/lib/genesis/bootstrap/scripts"
 
 GC_PG_USER="genesis_core"
 GC_PG_PASS="genesis_core"
@@ -51,6 +52,8 @@ sudo -u postgres psql -c "CREATE DATABASE $GC_PG_USER OWNER $GC_PG_DB;"
 sudo mkdir -p $GC_CFG_DIR
 sudo cp "$GC_PATH/etc/genesis_core/genesis_core.conf" $GC_CFG_DIR/
 sudo cp "$GC_PATH/etc/genesis_core/logging.yaml" $GC_CFG_DIR/
+sudo cp "$GC_PATH/scripts/bootstrap.sh" $BOOTSTRAP_PATH/0100-gc-bootstrap.sh
+python3 -m uuid | sudo tee /var/lib/genesis/node-id
 
 mkdir -p "$VENV_PATH"
 python3 -m venv "$VENV_PATH"
@@ -67,6 +70,7 @@ deactivate
 sudo ln -sf "$VENV_PATH/bin/gc-user-api" "/usr/bin/gc-user-api"
 sudo ln -sf "$VENV_PATH/bin/gc-orch-api" "/usr/bin/gc-orch-api"
 sudo ln -sf "$VENV_PATH/bin/gc-gservice" "/usr/bin/gc-gservice"
+sudo ln -sf "$VENV_PATH/bin/gc-bootstrap" "/usr/bin/gc-bootstrap"
 
 # Install Systemd service files
 sudo cp "$GC_PATH/etc/systemd/gc-user-api.service" $SYSTEMD_SERVICE_DIR

--- a/genesis_core/cmd/bootstrap.py
+++ b/genesis_core/cmd/bootstrap.py
@@ -1,0 +1,53 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+import time
+
+from oslo_config import cfg
+
+LOG = logging.getLogger(__name__)
+
+cli_opts = [
+    cfg.BoolOpt(
+        "retry_on_error",
+        default=True,
+        help="Should the script retry on errors",
+    ),
+]
+
+CONF = cfg.CONF
+CONF.register_cli_opts(cli_opts)
+
+
+def main() -> None:
+    cfg.CONF()
+    retry_on_error = CONF.retry_on_error
+
+    while True:
+        try:
+            LOG.info("GC Bootstrap script")
+            return
+        except Exception:
+            LOG.exception("Unable to perform bootstrap, retrying...")
+            if not retry_on_error:
+                return
+
+        time.sleep(2.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/genesis_core/node/constants.py
+++ b/genesis_core/node/constants.py
@@ -20,6 +20,8 @@ import typing as tp
 DEF_SQL_LIMIT = 300
 EP_MACHINE_POOL_DRIVERS = "gcn_machine_pool_driver"
 DEF_ROOT_DISK_SIZE = 15
+POLICY_SERVICE_NAME = "compute"
+
 
 BootType = tp.Literal["hd", "network", "cdrom"]
 

--- a/genesis_core/user_api/api/controllers.py
+++ b/genesis_core/user_api/api/controllers.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from gcl_iam import controllers as iam_controllers
 from restalchemy.api import controllers
 from restalchemy.api import resources
 
@@ -37,8 +38,13 @@ class HealthController(controllers.Controller):
 # Nodes
 
 
-class NodesController(controllers.BaseResourceController):
+class NodesController(
+    iam_controllers.PolicyBasedController,
+):
     """Controller for /v1/nodes/ endpoint"""
+
+    __policy_name__ = "node"
+    __policy_service_name__ = nc.POLICY_SERVICE_NAME
 
     __resource__ = resources.ResourceByRAModel(
         model_class=node_models.Node,
@@ -47,8 +53,13 @@ class NodesController(controllers.BaseResourceController):
     )
 
 
-class MachinesController(controllers.BaseResourceController):
+class MachinesController(
+    iam_controllers.PolicyBasedController,
+):
     """Controller for /v1/machines/ endpoint"""
+
+    __policy_name__ = "machine"
+    __policy_service_name__ = nc.POLICY_SERVICE_NAME
 
     __resource__ = resources.ResourceByRAModel(
         model_class=node_models.Machine,
@@ -57,8 +68,13 @@ class MachinesController(controllers.BaseResourceController):
     )
 
 
-class HypervisorsController(controllers.BaseResourceController):
+class HypervisorsController(
+    iam_controllers.PolicyBasedController,
+):
     """Controller for /v1/hypervisors/ endpoint"""
+
+    __policy_name__ = "hypervisor"
+    __policy_service_name__ = nc.POLICY_SERVICE_NAME
 
     __resource__ = resources.ResourceByRAModel(
         model_class=node_models.MachinePool,
@@ -76,8 +92,13 @@ class HypervisorsController(controllers.BaseResourceController):
         return hyper
 
 
-class MachineAgentController(controllers.BaseResourceController):
+class MachineAgentController(
+    iam_controllers.PolicyBasedController,
+):
     """Controller for /v1/machine_agents/ endpoint"""
+
+    __policy_name__ = "machine_agent"
+    __policy_service_name__ = nc.POLICY_SERVICE_NAME
 
     __resource__ = resources.ResourceByRAModel(
         model_class=node_models.MachineAgent,

--- a/migrations/0012-compute-permissions-aac851.py
+++ b/migrations/0012-compute-permissions-aac851.py
@@ -1,0 +1,136 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import uuid as sys_uuid
+from restalchemy.storage.sql import migrations
+
+
+NS_UUID = sys_uuid.UUID("dfd0c604-607f-4260-981f-374f88435ea0")
+GENESIS_CORE_ORG_UUID = "11111111-1111-1111-1111-111111111111"
+OWNER_ROLE_UUID = "726f6c65-0000-0000-0000-000000000002"
+
+COMPUTE_NODE_DEF_PERMISSIONS = (
+    ("compute.node.read", "List and read own nodes"),
+    ("compute.node.create", "Create own nodes"),
+    ("compute.node.update", "Update own nodes"),
+    ("compute.node.delete", "Delete own nodes"),
+)
+
+
+def _u(name: str) -> str:
+    return str(sys_uuid.uuid5(NS_UUID, name))
+
+
+COMPUTE_PROJECT_UUID = _u("GenesisCore-Compute-Project")
+
+
+class MigrationStep(migrations.AbstarctMigrationStep):
+
+    def __init__(self):
+        self._depends = ["0011-add-surname-and-phone-ea974b.py"]
+
+    @property
+    def migration_id(self):
+        return "aac8510e-9a0d-4db5-9a94-7bc8abff40e1"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def _create_permissions(self, session):
+        for name, description in COMPUTE_NODE_DEF_PERMISSIONS:
+            session.execute(
+                f"""
+                INSERT INTO iam_permissions (
+                    uuid, name, description
+                ) VALUES (
+                    '{_u(name)}',
+                    '{name}',
+                    '{description}'
+                )
+                ON CONFLICT (uuid) DO NOTHING;
+            """
+            )
+
+    def _create_project(self, session):
+        session.execute(
+            f"""
+            INSERT INTO iam_projects (
+                uuid, name, description, organization
+            ) VALUES (
+                '{COMPUTE_PROJECT_UUID}',
+                'compute-core',
+                'Comptue and Baremetal Core Project',
+                '{GENESIS_CORE_ORG_UUID}'
+            )
+            ON CONFLICT (uuid) DO NOTHING;
+        """
+        )
+
+    def _create_bindings(self, session):
+        for name, _ in COMPUTE_NODE_DEF_PERMISSIONS:
+            session.execute(
+                f"""
+                INSERT INTO iam_binding_permissions (
+                    uuid, role, permission, project_id
+                ) VALUES (
+                    gen_random_uuid(),
+                    '{OWNER_ROLE_UUID}',
+                    '{_u(name)}',
+                    '{COMPUTE_PROJECT_UUID}'
+                );
+            """
+            )
+
+    def upgrade(self, session):
+        self._create_permissions(session)
+        self._create_project(session)
+        self._create_bindings(session)
+
+    def _delete_bindings(self, session):
+        for name, _ in COMPUTE_NODE_DEF_PERMISSIONS:
+            session.execute(
+                f"""
+                DELETE FROM iam_binding_permissions
+                WHERE
+                    permission = '{_u(name)}';
+            """
+            )
+
+    def _delete_project(self, session):
+        session.execute(
+            f"""
+            DELETE FROM iam_projects
+            WHERE uuid = '{COMPUTE_PROJECT_UUID}';
+        """
+        )
+
+    def _delete_permissions(self, session):
+        for name, _ in COMPUTE_NODE_DEF_PERMISSIONS:
+            session.execute(
+                f"""
+                DELETE FROM iam_permissions
+                WHERE uuid = '{_u(name)}';
+            """
+            )
+
+    def downgrade(self, session):
+        self._delete_bindings(session)
+        self._delete_project(session)
+        self._delete_permissions(session)
+
+
+migration_step = MigrationStep()

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+set -eu
+set -x
+set -o pipefail
+
+# Perform the bootstrap of GC
+gc-bootstrap

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ console_scripts =
     gc-user-api = genesis_core.cmd.user_api:main
     gc-orch-api = genesis_core.cmd.orch_api:main
     gc-gservice = genesis_core.cmd.gservice:main
+    gc-bootstrap = genesis_core.cmd.bootstrap:main
 gcn_machine_pool_driver =
     DummyPoolDriver = genesis_core.node.machine.pool.driver.base:DummyPoolDriver
     LibvirtPoolDriver = genesis_core.node.machine.pool.driver.libvirt:LibvirtPoolDriver


### PR DESCRIPTION
## Base permissions for nodes
This MR adds base permission for the owner project:
- compute.node.read
- compute.node.create
- compute.node.update
- compute.node.delete

## Bootstrap script
The profile was changed to `genesis-base` to have support of bootstrap scripts. A first dummy version of the bootstrap scripts was added.