### PR TITLE
Enhance authentication error handling in IAM tests

### DIFF
--- a/genesis_core/tests/functional/restapi/iam/test_clients.py
+++ b/genesis_core/tests/functional/restapi/iam/test_clients.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from bazooka import exceptions as bazooka_exc
 import pytest
 
 from genesis_core.user_api.iam import constants as c
@@ -60,3 +61,10 @@ class TestClients:
         assert result["user"]["uuid"] == auth_test1_p1_user.uuid
         assert len(result["organization"]) == 1
         assert result["project_id"] == auth_test1_p1_user.project_id
+
+    def test_http_code_with_invalid_token(self, user_api_noauth_client):
+        client = user_api_noauth_client()
+        url = client.build_collection_uri(["iam/roles"])
+
+        with pytest.raises(bazooka_exc.UnauthorizedError):
+            client.get(url)

--- a/genesis_core/tests/functional/restapi/iam/test_organizations.py
+++ b/genesis_core/tests/functional/restapi/iam/test_organizations.py
@@ -30,7 +30,7 @@ class TestOrganizations:
     ):
         client = user_api_noauth_client()
 
-        with pytest.raises(bazooka_exc.BadRequestError):
+        with pytest.raises(bazooka_exc.UnauthorizedError):
             client.create_organization(name="TestOrganization")
 
     def _create_organization(self, client, user, info=None):

--- a/genesis_core/tests/functional/restapi/iam/test_users.py
+++ b/genesis_core/tests/functional/restapi/iam/test_users.py
@@ -35,7 +35,7 @@ class TestUsers:
     def test_list_users_wo_auth_bad_request(self, user_api_noauth_client):
         client = user_api_noauth_client()
 
-        with pytest.raises(bazooka_exc.BadRequestError):
+        with pytest.raises(bazooka_exc.UnauthorizedError):
             client.list_users()
 
     def test_list_users_admin_auth_success(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gcl_looper>=0.1.0,<=1.0.0  # Apache-2.0
 restalchemy>=12.5.1,<13.0.0  # Apache-2.0
 libvirt-python>=11.0.0,<12.0.0  # GNU Lesser General Public License v2 or later (LGPLv2+)
 Authlib>=1.5.0,<2.0.0  # BSD License (BSD-3-Clause)
-bazooka>=1.2.0,<2.0.0  # Apache-2.0
+bazooka>=1.3.0,<2.0.0  # Apache-2.0
 Jinja2>=3.1.5,<4.0.0  # BSD License (BSD-3-Clause)
 izulu>=0.5.6,<1.0.0  # MIT License
-gcl_iam>=0.4.0,<1.0.0  # Apache-2.0
+gcl_iam>=0.4.1,<1.0.0  # Apache-2.0


### PR DESCRIPTION
Updated test cases to validate correct `UnauthorizedError` exceptions for unauthenticated requests instead of `BadRequestError`, improving error response accuracy. Added new test `test_http_code_with_invalid_token` in `test_clients.py` to verify proper 401 status code behavior when invalid tokens are used.

**Update dependencies for compatibility**
Bumped `bazooka` version to `1.3.0` and `gcl_iam` to `0.4.1` in `requirements.txt` to leverage latest exception handling improvements and security fixes.