### PR TITLE
Automatically assign default roles for new users and projects

### DIFF
--- a/genesis_core/tests/functional/restapi/iam/base.py
+++ b/genesis_core/tests/functional/restapi/iam/base.py
@@ -1,0 +1,24 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+class BaseIamResourceTest:
+
+    def _has_role(self, roles, role_uuid):
+        for role in roles:
+            if role["uuid"] == role_uuid:
+                return True
+        return False

--- a/genesis_core/tests/functional/restapi/iam/test_clients.py
+++ b/genesis_core/tests/functional/restapi/iam/test_clients.py
@@ -17,10 +17,11 @@
 from bazooka import exceptions as bazooka_exc
 import pytest
 
+from genesis_core.tests.functional.restapi.iam import base
 from genesis_core.user_api.iam import constants as c
 
 
-class TestClients:
+class TestClients(base.BaseIamResourceTest):
 
     def test_me_wo_organization_success(
         self, user_api_client, auth_test1_user

--- a/genesis_core/tests/functional/restapi/iam/test_organizations.py
+++ b/genesis_core/tests/functional/restapi/iam/test_organizations.py
@@ -17,10 +17,11 @@
 from bazooka import exceptions as bazooka_exc
 import pytest
 
+from genesis_core.tests.functional.restapi.iam import base
 from genesis_core.user_api.iam import constants as c
 
 
-class TestOrganizations:
+class TestOrganizations(base.BaseIamResourceTest):
 
     ORGS_ENDPOINT = "iam/organizations"
     ORGS_BINDINGS_ENDPOINT = "iam/organization_members"

--- a/genesis_core/tests/functional/restapi/iam/test_projects.py
+++ b/genesis_core/tests/functional/restapi/iam/test_projects.py
@@ -1,0 +1,46 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from bazooka import exceptions as bazooka_exc
+import pytest
+
+from genesis_core.common import constants as common_c
+from genesis_core.tests.functional.restapi.iam import base
+from genesis_core.user_api.iam import constants as c
+
+
+class TestProjects(base.BaseIamResourceTest):
+
+    def test_create_user_and_check_roles(
+        self, user_api_client, auth_test1_user
+    ):
+        client = user_api_client(
+            auth_test1_user,
+            permissions=[
+                c.PERMISSION_ORGANIZATION_CREATE,
+            ],
+        )
+        org = client.create_organization(
+            name="TestOrganization",
+        )
+
+        client.create_project(
+            name="TestProject",
+            organization_uuid=org["uuid"],
+        )
+
+        roles = client.get_user_roles(auth_test1_user.uuid)
+        assert self._has_role(roles, common_c.OWNER_ROLE_UUID)

--- a/genesis_core/user_api/iam/api/routes.py
+++ b/genesis_core/user_api/iam/api/routes.py
@@ -34,12 +34,19 @@ class ChangePasswordAction(routes.Action):
     __controller__ = controllers.UserController
 
 
+class GetMyRolesAction(routes.Action):
+    """Handler for .../users/<uuid>/actions/get_my_roles endpoint"""
+
+    __controller__ = controllers.UserController
+
+
 class UserRoute(routes.Route):
     """Handler for /v1/iam/users/ endpoint"""
 
     __controller__ = controllers.UserController
 
     change_password = routes.action(ChangePasswordAction, invoke=True)
+    get_my_roles = routes.action(GetMyRolesAction)
 
 
 class OrganizationController(routes.Route):

--- a/genesis_core/user_api/iam/constants.py
+++ b/genesis_core/user_api/iam/constants.py
@@ -79,6 +79,9 @@ class OrganizationRole(str, enum.Enum):
 PERMISSION_USER_LISTING = rules.Rule.from_raw(
     "iam.user.list",
 )
+PERMISSION_USER_READ_ALL = rules.Rule.from_raw(
+    "iam.user.read_all",
+)
 PERMISSION_USER_WRITE_ALL = rules.Rule.from_raw(
     "iam.user.write_all",
 )

--- a/genesis_core/user_api/iam/exceptions.py
+++ b/genesis_core/user_api/iam/exceptions.py
@@ -56,6 +56,13 @@ class CanNotDeleteUser(exceptions.CommonForbiddenException, iam_exc.Forbidden):
     )
 
 
+class CanNotReadUser(exceptions.CommonForbiddenException, iam_exc.Forbidden):
+    __template__ = (
+        "The current user is not permitted to read the user `{uuid}`."
+        " This action requires the `{rule}`, which has not been granted."
+    )
+
+
 class CanNotUpdateOrganization(
     exceptions.CommonForbiddenException,
     iam_exc.Forbidden,

--- a/migrations/0007-add-default-roles-73f4c4.py
+++ b/migrations/0007-add-default-roles-73f4c4.py
@@ -75,6 +75,10 @@ class MigrationStep(migrations.AbstarctMigrationStep):
 
     def downgrade(self, session):
         delete_queries = [
+            "DELETE FROM iam_binding_roles WHERE"
+            f"  role = '{NEWCOMER_ROLE_UUID}';",
+            "DELETE FROM iam_binding_roles WHERE"
+            f"  role = '{OWNER_ROLE_UUID}';",
             f"DELETE FROM iam_roles WHERE uuid = '{NEWCOMER_ROLE_UUID}';",
             f"DELETE FROM iam_roles WHERE uuid = '{OWNER_ROLE_UUID}';",
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ Authlib>=1.5.0,<2.0.0  # BSD License (BSD-3-Clause)
 bazooka>=1.3.0,<2.0.0  # Apache-2.0
 Jinja2>=3.1.5,<4.0.0  # BSD License (BSD-3-Clause)
 izulu>=0.5.6,<1.0.0  # MIT License
-gcl_iam>=0.4.1,<1.0.0  # Apache-2.0
+gcl_iam>=0.5.0,<1.0.0  # Apache-2.0


### PR DESCRIPTION
- Extend `UserController.create` to call `user.make_newcomer()`, assigning the `NEWCOMER` role via a new `RoleBinding` upon user creation.
- Extend `ProjectController.create` to call `project.add_owner(models.User.me())`, binding the current user to the `OWNER` role for the newly created project.