### PR TITLE
Switch base classes from `ModelWithNameDesc` to `ModelWithRequiredNameDesc`

### DIFF
--- a/genesis_core/user_api/iam/dm/models.py
+++ b/genesis_core/user_api/iam/dm/models.py
@@ -151,7 +151,7 @@ class RolesInfo:
 
 class User(
     models.ModelWithUUID,
-    models.ModelWithNameDesc,
+    models.ModelWithRequiredNameDesc,
     models.ModelWithTimestamp,
     ModelWithSecret,
     ModelWithAlwaysActiveStatus,
@@ -168,7 +168,15 @@ class User(
         types.String(min_length=1, max_length=128),
         required=True,
     )
+    surname = properties.property(
+        types.String(min_length=0, max_length=128),
+        default="",
+    )
 
+    phone = properties.property(
+        types.String(min_length=0, max_length=15),
+        default=None,
+    )
     email = properties.property(
         types.Email(max_length=128),
         required=True,
@@ -231,7 +239,7 @@ class User(
 
 class Role(
     models.ModelWithUUID,
-    models.ModelWithNameDesc,
+    models.ModelWithRequiredNameDesc,
     models.ModelWithTimestamp,
     ModelWithAlwaysActiveStatus,
     orm.SQLStorableMixin,
@@ -247,7 +255,7 @@ class Role(
 
 class Permission(
     models.ModelWithUUID,
-    models.ModelWithNameDesc,
+    models.ModelWithRequiredNameDesc,
     models.ModelWithTimestamp,
     ModelWithAlwaysActiveStatus,
     orm.SQLStorableMixin,
@@ -280,7 +288,7 @@ class PermissionBinding(
 
 class Organization(
     models.ModelWithUUID,
-    models.ModelWithNameDesc,
+    models.ModelWithRequiredNameDesc,
     models.ModelWithTimestamp,
     ModelWithAlwaysActiveStatus,
     orm.SQLStorableWithJSONFieldsMixin,
@@ -355,7 +363,7 @@ class OrganizationMember(
 
 class Project(
     models.ModelWithUUID,
-    models.ModelWithNameDesc,
+    models.ModelWithRequiredNameDesc,
     models.ModelWithTimestamp,
     ModelWithStatus,
     orm.SQLStorableMixin,
@@ -434,7 +442,7 @@ class RoleBinding(
 
 class Idp(
     models.ModelWithUUID,
-    models.ModelWithNameDesc,
+    models.ModelWithRequiredNameDesc,
     models.ModelWithTimestamp,
     ModelWithSecret,
     ModelWithAlwaysActiveStatus,
@@ -714,7 +722,7 @@ class MeInfo:
 
 class IamClient(
     models.ModelWithUUID,
-    models.ModelWithNameDesc,
+    models.ModelWithRequiredNameDesc,
     models.ModelWithTimestamp,
     ModelWithSecret,
     ModelWithAlwaysActiveStatus,

--- a/migrations/0011-add-surname-and-phone-ea974b.py
+++ b/migrations/0011-add-surname-and-phone-ea974b.py
@@ -1,0 +1,63 @@
+# Copyright 2016 Eugene Frolov <eugene@frolov.net.ru>
+# Copyright 2025 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import migrations
+
+
+class MigrationStep(migrations.AbstarctMigrationStep):
+
+    def __init__(self):
+        self._depends = ["0010-image-for-machine-31471a.py"]
+
+    @property
+    def migration_id(self):
+        return "ea974b0f-e5d0-4e17-8543-3770eca8df85"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        session.execute(
+            """
+            ALTER TABLE "iam_users"
+            ADD COLUMN surname VARCHAR(128) NOT NULL DEFAULT ''
+        """
+        )
+        session.execute(
+            """
+            ALTER TABLE "iam_users"
+            ADD COLUMN phone VARCHAR(15)
+        """
+        )
+
+    def downgrade(self, session):
+        session.execute(
+            """
+            ALTER TABLE "iam_users"
+            DROP COLUMN surname
+        """
+        )
+        session.execute(
+            """
+            ALTER TABLE "iam_users"
+            DROP COLUMN phone
+        """
+        )
+
+
+migration_step = MigrationStep()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pbr>=1.10.0,<=5.8.1  # Apache-2.0
 oslo.config>=3.22.2,<10.0.0  # Apache-2.0
 bjoern>=3.2.2  # BSD License (BSD-3-Clause)
 gcl_looper>=0.1.0,<=1.0.0  # Apache-2.0
-restalchemy>=12.5.1,<13.0.0  # Apache-2.0
+restalchemy>=12.7.0,<13.0.0  # Apache-2.0
 libvirt-python>=11.0.0,<12.0.0  # GNU Lesser General Public License v2 or later (LGPLv2+)
 Authlib>=1.5.0,<2.0.0  # BSD License (BSD-3-Clause)
 bazooka>=1.3.0,<2.0.0  # Apache-2.0


### PR DESCRIPTION


Updated `User`, `Role`, `Permission`, `Organization`, `Project`, `Idp`, and `IamClient` models to inherit from `ModelWithRequiredNameDesc`, enforcing required `name` and `description` fields across these entities.

**Add `surname` and `phone` fields to the `User` model**
- Introduced `surname` as an optional string field (max length 128) with a default empty string.
- Added `phone` as an optional string field (max length 15) with a default value of `None`.
- Included a new migration (`0011-add-surname-and-phone-ea974b.py`) to add corresponding columns (`surname` and `phone`) to the `iam_users` database table.

**Bump `restalchemy` dependency to version 12.7.0** Updated `requirements.txt` to require `restalchemy>=12.7.0`, aligning with changes that depend on newer features or fixes in the library.