### PR TITLE
Implement project-scoped token handling for authentication flows

### DIFF
--- a/genesis_core/tests/functional/restapi/iam/test_clients.py
+++ b/genesis_core/tests/functional/restapi/iam/test_clients.py
@@ -14,11 +14,16 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import uuid as sys_uuid
+
 from bazooka import exceptions as bazooka_exc
 import pytest
 
 from genesis_core.tests.functional.restapi.iam import base
 from genesis_core.user_api.iam import constants as c
+
+
+TEST_PROJECT_ID = str(sys_uuid.uuid4())
 
 
 class TestClients(base.BaseIamResourceTest):
@@ -66,3 +71,133 @@ class TestClients(base.BaseIamResourceTest):
 
         with pytest.raises(bazooka_exc.UnauthorizedError):
             client.get(url)
+
+    @pytest.fixture(
+        scope="function",
+        params=[
+            ("project",),
+            ("project:default",),
+            (f"project:{TEST_PROJECT_ID}",),
+        ],
+    )
+    def scope_test(self, request):
+        return request.param[0]
+
+    def test_get_scoped_token_no_project_no_organization_success(
+        self, user_api_client, auth_test1_user, hs256_algorithm, scope_test
+    ):
+        client = user_api_client(auth_test1_user)
+        token_params = auth_test1_user.get_password_auth_params()
+        token_params["scope"] = scope_test
+
+        token_info = client.post(
+            url=auth_test1_user.get_token_url(endpoint=client.endpoint),
+            data=token_params,
+        ).json()
+
+        id_token = hs256_algorithm.decode(
+            token_info["id_token"], ignore_audience=True
+        )
+        assert token_info["scope"] == scope_test
+        assert id_token["project_id"] is None
+
+    def test_get_scoped_token_no_project_one_organization_success(
+        self, user_api_client, auth_test1_user, hs256_algorithm, scope_test
+    ):
+        client = user_api_client(auth_test1_user)
+        client.create_organization("OrganizationName1")
+        token_params = auth_test1_user.get_password_auth_params()
+        token_params["scope"] = scope_test
+
+        token_info = client.post(
+            url=auth_test1_user.get_token_url(endpoint=client.endpoint),
+            data=token_params,
+        ).json()
+
+        id_token = hs256_algorithm.decode(
+            token_info["id_token"], ignore_audience=True
+        )
+        assert token_info["scope"] == scope_test
+        assert id_token["project_id"] is None
+
+    def test_get_scoped_token_one_project_one_organization_success(
+        self, user_api_client, auth_test1_user, hs256_algorithm, scope_test
+    ):
+        client = user_api_client(auth_test1_user)
+        org = client.create_organization("OrganizationName1")
+        project = client.create_project(
+            org["uuid"], "ProjectName1", uuid=TEST_PROJECT_ID
+        )
+        token_params = auth_test1_user.get_password_auth_params()
+        token_params["scope"] = scope_test
+
+        token_info = client.post(
+            url=auth_test1_user.get_token_url(endpoint=client.endpoint),
+            data=token_params,
+        ).json()
+
+        id_token = hs256_algorithm.decode(
+            token_info["id_token"], ignore_audience=True
+        )
+        assert token_info["scope"] == scope_test
+        assert id_token["project_id"] == project["uuid"]
+
+    def test_get_scoped_token_two_project_two_organization_success(
+        self, user_api_client, auth_test1_user, hs256_algorithm, scope_test
+    ):
+        client = user_api_client(auth_test1_user)
+        org1 = client.create_organization("OrganizationName1")
+        project = client.create_project(
+            org1["uuid"], "ProjectName1Org1", uuid=TEST_PROJECT_ID
+        )
+        client.create_project(org1["uuid"], "ProjectName2Org1")
+        org2 = client.create_organization("OrganizationName2")
+        client.create_project(org2["uuid"], "ProjectName1Org2")
+        client.create_project(org2["uuid"], "ProjectName2Org2")
+        token_params = auth_test1_user.get_password_auth_params()
+        token_params["scope"] = scope_test
+
+        token_info = client.post(
+            url=auth_test1_user.get_token_url(endpoint=client.endpoint),
+            data=token_params,
+        ).json()
+
+        id_token = hs256_algorithm.decode(
+            token_info["id_token"], ignore_audience=True
+        )
+        assert token_info["scope"] == scope_test
+        assert id_token["project_id"] == project["uuid"]
+
+    def test_refresh_to_scoped_token_one_project_one_organization_success(
+        self, user_api_client, auth_test1_user, hs256_algorithm, scope_test
+    ):
+        client = user_api_client(auth_test1_user)
+        org = client.create_organization("OrganizationName1")
+        project = client.create_project(
+            org["uuid"], "ProjectName1", uuid=TEST_PROJECT_ID
+        )
+        token_params = auth_test1_user.get_password_auth_params()
+        token_info = client.post(
+            url=auth_test1_user.get_token_url(endpoint=client.endpoint),
+            data=token_params,
+        ).json()
+
+        refreshed_token_info = client.post(
+            url=auth_test1_user.get_token_url(endpoint=client.endpoint),
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": token_info["refresh_token"],
+                "scope": scope_test,
+            },
+        ).json()
+
+        first_id_token = hs256_algorithm.decode(
+            token_info["id_token"], ignore_audience=True
+        )
+        second_id_token = hs256_algorithm.decode(
+            refreshed_token_info["id_token"], ignore_audience=True
+        )
+        assert token_info["scope"] == ""
+        assert first_id_token["project_id"] is None
+        assert refreshed_token_info["scope"] == scope_test
+        assert second_id_token["project_id"] == project["uuid"]

--- a/genesis_core/user_api/iam/api/controllers.py
+++ b/genesis_core/user_api/iam/api/controllers.py
@@ -349,6 +349,7 @@ class ClientsController(controllers.BaseResourceController):
         elif grant_type == c.GRANT_TYPE_REFRESH_TOKEN:
             token = resource.get_token_by_refresh_token(
                 refresh_token=kwargs.get("refresh_token"),
+                scope=kwargs.get(c.PARAM_SCOPE, None),
             )
             return token.get_response_body()
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ Authlib>=1.5.0,<2.0.0  # BSD License (BSD-3-Clause)
 bazooka>=1.3.0,<2.0.0  # Apache-2.0
 Jinja2>=3.1.5,<4.0.0  # BSD License (BSD-3-Clause)
 izulu>=0.5.6,<1.0.0  # MIT License
-gcl_iam>=0.5.0,<1.0.0  # Apache-2.0
+gcl_iam>=0.6.0,<1.0.0  # Apache-2.0


### PR DESCRIPTION
Added support for generating and refreshing tokens with project-based scopes via password and refresh token grants. The JWT `id_token` now includes `project_id` claim when scoped to a project.

**Add comprehensive tests for scope scenarios**
New test cases validate token behavior with:
- No projects/organizations
- Single/multiple organizations
- Default/explicit project UUIDs in scopes
- Token refresh operations with scope changes

**Refactor project resolution logic**
Moved project detection methods (`_get_default_project`, `_get_project_by_uuid`, `_get_project_by_scope`) from `IamClient` to `Token` model for better encapsulation.

**Update refresh token flow**
Modified `Token.refresh()` to accept optional `scope` parameter, allowing scope changes during refresh operations. The refresh token grant in `ClientsController` now propagates scope requests to refreshed tokens.

**Improve token initialization**
`Token` constructor now automatically resolves project associations during creation based on provided scope.