### PR TITLE
Improve unscoped token handling and update default scope

### DIFF
--- a/genesis_core/user_api/iam/constants.py
+++ b/genesis_core/user_api/iam/constants.py
@@ -36,7 +36,7 @@ PARAM_SCOPE = "scope"
 
 
 # Default Values
-PARAM_SCOPE_DEFAULT = "openid, project:default"
+PARAM_SCOPE_DEFAULT = ""
 
 
 # Algorithms

--- a/genesis_core/user_api/iam/dm/models.py
+++ b/genesis_core/user_api/iam/dm/models.py
@@ -659,6 +659,7 @@ class Token(
         return project
 
     def refresh(self, scope=None):
+        scope = scope or self.scope
         now = datetime.datetime.now(datetime.timezone.utc)
         new_expiration_at = now + Token.expiration_delta
         self.expiration_at = new_expiration_at


### PR DESCRIPTION
Updated the default value for `PARAM_SCOPE_DEFAULT` to an empty string, removing the previous `openid, project:default` assignment. This ensures tokens are not automatically scoped unless explicitly requested.  

**Added comprehensive test coverage**  
- New test cases (`test_get_no_scoped_token_success`, `test_get_empty_scoped_token_success`, `test_refresh_token_wo_scope_success`) validate token behavior when no scope or an empty scope is provided.  
- Tests verify that returned tokens have empty `scope` fields and `project_id` set to `None` in decoded ID tokens.  

**Fixed token refresh scope persistence**  
Modified the `Token.refresh()` method to retain the original token's scope when no new scope is provided during refresh. This prevents unintended scope changes and ensures consistency between initial and refreshed tokens.  

**Security and correctness enhancements**  
- Ensures unscoped tokens do not inherit unintended project/organization contexts.  
- Aligns token behavior with expectations for scenarios where explicit scoping is not required.