### PR TITLE
More configuration options for Orch API, Machine Pools

### DIFF
--- a/genesis_core/cmd/orch_api.py
+++ b/genesis_core/cmd/orch_api.py
@@ -43,6 +43,26 @@ api_cli_opts = [
         default=1,
         help="How many http servers should be started",
     ),
+    cfg.StrOpt(
+        "gc_host",
+        default="10.20.0.2",
+        help="GC host",
+    ),
+    cfg.IntOpt(
+        "gc_port",
+        default=11011,
+        help="GC port",
+    ),
+    cfg.StrOpt(
+        "kernel",
+        default=None,
+        help="Endpoint for Linux kernel",
+    ),
+    cfg.StrOpt(
+        "initrd",
+        default=None,
+        help="Endpoint for Linux initrd",
+    ),
 ]
 
 

--- a/genesis_core/orch_api/api/controllers.py
+++ b/genesis_core/orch_api/api/controllers.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from oslo_config import cfg
 from restalchemy.api import controllers
 from restalchemy.api import resources
 from restalchemy.storage import exceptions as ra_storage_exceptions
@@ -21,6 +22,9 @@ from restalchemy.storage import exceptions as ra_storage_exceptions
 from genesis_core.node import constants as nc
 from genesis_core.orch_api.dm import models as node_models
 from genesis_core.orch_api.api import packers
+
+DOMAIN = "orch_api"
+CONF = cfg.CONF
 
 
 class ApiEndpointController(controllers.RoutesListController):
@@ -79,5 +83,13 @@ class NetBootController(controllers.BaseResourceController):
                 uuid=uuid,
                 boot=nc.BootAlternative.network.value,
             )
+
+        # Set netboot configuration
+        netboot.set_netboot_params(
+            CONF[DOMAIN].gc_host,
+            CONF[DOMAIN].gc_port,
+            CONF[DOMAIN].kernel,
+            CONF[DOMAIN].initrd,
+        )
 
         return netboot, 200, {"Content-Type": "application/octet-stream"}

--- a/genesis_core/orch_api/api/packers.py
+++ b/genesis_core/orch_api/api/packers.py
@@ -23,10 +23,10 @@ from genesis_core.orch_api.dm import models
 
 _from_net_template = """#!ipxe
 :kernel
-kernel tftp://{gc_host}/bios/vmlinuz showopts ip=dhcp net.ifnames=0 biosdevname=0 gc_base_url=http://{gc_host}:{gc_port} || goto kernel
+kernel {kernel} showopts ip=dhcp net.ifnames=0 biosdevname=0 gc_base_url=http://{gc_host}:{gc_port} || goto kernel
 
 :initrd
-initrd tftp://{gc_host}/bios/initrd.img || goto initrd
+initrd {initrd} || goto initrd
 boot
 """
 
@@ -45,7 +45,10 @@ class IPXEPacker(packers.JSONPacker):
 
         if boot == nc.BootAlternative.network:
             return _from_net_template.format(
-                gc_host=obj.gc_host, gc_port=obj.gc_port
+                gc_host=obj.gc_host,
+                gc_port=obj.gc_port,
+                kernel=obj.kernel,
+                initrd=obj.initrd,
             )
         elif boot.boot_type == "hd":
             return _from_hd_template.format(disk_number=boot.value[2])


### PR DESCRIPTION
# Orch API
It adds more configuration options for the orch api. Now it's possible to specify location of kernel and initrd. Also all hardcode was removed. These paramters are configurable as well.

# Libvirt Machine Pool:
New options for driver specification were added:
- mtu. Set default mtu size for virtual machines on the hyper.
- Interface ROM file. Ability to use a custom firmware for netwrok interfaces of virtual machines on a specific hyper.

# Other
Also a couple bug fixes.