### PR TITLE
Allow unannotated fields for Izulu exceptions

### DIFF
--- a/genesis_core/common/exceptions.py
+++ b/genesis_core/common/exceptions.py
@@ -18,6 +18,7 @@ from izulu import root
 
 
 class GCException(root.Error):
+    __toggles__ = root.Toggles.DEFAULT ^ root.Toggles.FORBID_UNANNOTATED_FIELDS
     __template__ = "An unknown exception occurred."
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ libvirt-python>=11.0.0,<12.0.0  # GNU Lesser General Public License v2 or later 
 Authlib>=1.5.0,<2.0.0  # BSD License (BSD-3-Clause)
 bazooka>=1.3.0,<2.0.0  # Apache-2.0
 Jinja2>=3.1.5,<4.0.0  # BSD License (BSD-3-Clause)
-izulu>=0.5.6,<1.0.0  # MIT License
+izulu>=0.50.0,<1.0.0  # MIT License
 gcl_iam>=0.7.1,<1.0.0  # Apache-2.0


### PR DESCRIPTION
The default behaviour of Izulu package was changend, it restricted unannotated fields. Enable original behaviour using special options.