### PR TITLE
Base implementation of baremetal node support

### DIFF
--- a/genesis/images/startup_cfg.yaml
+++ b/genesis/images/startup_cfg.yaml
@@ -1,4 +1,9 @@
 startup_entities:
+  machine_pools:
+    - uuid: "2bd17956-600b-4beb-8ddd-9fc4856262e6"
+      name: "default-hw-pool"
+      machine_type: HW
+      status: ACTIVE
   networks:
     - name: flat
       uuid: "1d4f64db-817a-4862-a588-c9e950823cc1"
@@ -10,6 +15,7 @@ startup_entities:
           uuid: "c910a7e1-61ae-4d56-bdd6-a59faa3cbda3"
           cidr: "10.20.0.0/22"
           ip_range: "10.20.0.20-10.20.0.200"
+          ip_discovery_range: "10.20.1.10-10.20.1.40"
           dns_servers: ["8.8.8.8"]
           routers:
             - to: "0.0.0.0/0"

--- a/genesis_core/cmd/bootstrap.py
+++ b/genesis_core/cmd/bootstrap.py
@@ -99,6 +99,16 @@ def _apply_startup_db():
                 else:
                     LOG.info("Created port %s", port.uuid)
 
+    # Handle pools
+    for pool in startup_entities.get("machine_pools", []):
+        pool = models.MachinePool.restore_from_simple_view(**pool)
+        try:
+            pool.insert()
+        except ra_exceptions.ConflictRecords:
+            LOG.info("Machine pool %s already exists", pool.uuid)
+        else:
+            LOG.info("Created machine pool %s", pool.uuid)
+
 
 def main() -> None:
     # Parse config

--- a/genesis_core/gservice/service.py
+++ b/genesis_core/gservice/service.py
@@ -36,18 +36,27 @@ class GeneralService(basic.BasicService):
         super().__init__(iter_min_period, iter_pause)
 
         # TODO(akremenetsky): Form a pipliene from the configuration
-        scheduler_filters = [
+        # and entry points
+        pool_filters = [
             available.CoresRamAvailableFilter(),
         ]
-        scheduler_weighters = [
+        pool_weighters = [
             relative.RelativeCoreRamWeighter(),
+        ]
+        machine_filters = [
+            available.HWCoresRamAvailableFilter(),
+        ]
+        machine_weighters = [
+            relative.SimpleMachineWeighter(),
         ]
 
         # The simplest way to enable the nested services
         # It will be reworked in the future
         n_scheduler = n_scheduler_service.NodeSchedulerService(
-            filters=scheduler_filters,
-            weighters=scheduler_weighters,
+            pool_filters=pool_filters,
+            pool_weighters=pool_weighters,
+            machine_filters=machine_filters,
+            machine_weighters=machine_weighters,
             iter_min_period=1,
             iter_pause=0.1,
         )

--- a/genesis_core/network/dhcp/isc.py
+++ b/genesis_core/network/dhcp/isc.py
@@ -130,10 +130,11 @@ def dhcp_config(subnets: tp.Dict[models.Subnet, tp.List[models.Port]]) -> str:
 
     # Build every subnet
     for subnet, ports in subnets.items():
-
-        # TODO(akremenetsky): Add pool when auto-discovery is enabled
-        # for baremetal discovery
-        pool = ""
+        start_ip, end_ip = subnet.ip_discovery_range_pair
+        pool = _auto_discovery_pool_template.format(
+            start_ip=str(start_ip),
+            end_ip=str(end_ip),
+        )
 
         hosts = ""
         for port in ports:

--- a/genesis_core/network/dm/models.py
+++ b/genesis_core/network/dm/models.py
@@ -20,15 +20,21 @@ from restalchemy.dm import relationships
 from genesis_core.node.dm import models
 
 
-class Port(models.Port, models.CastToBaseMixin):
-    __cast_filels__ = ("node", "machine", "subnet")
+class Subnet(models.Subnet, models.CastToBaseMixin):
+    __cast_fields__ = ("network",)
 
-    subnet = relationships.relationship(models.Subnet, prefetch=True)
+    network = relationships.relationship(models.Network, prefetch=True)
+
+
+class Port(models.Port, models.CastToBaseMixin):
+    __cast_fields__ = ("node", "machine", "subnet")
+
+    subnet = relationships.relationship(Subnet, prefetch=True)
     node = relationships.relationship(models.Node, prefetch=True)
     machine = relationships.relationship(models.Machine, prefetch=True)
 
 
-class Subnet(models.Subnet, models.CastToBaseMixin):
-    __cast_filels__ = ("network",)
-
-    network = relationships.relationship(models.Network, prefetch=True)
+class HWNodeWithoutPorts(models.HWNodeWithoutPorts):
+    node = relationships.relationship(models.Node, prefetch=True)
+    machine = relationships.relationship(models.Machine, prefetch=True)
+    iface = relationships.relationship(models.Interface, prefetch=True)

--- a/genesis_core/node/machine/dm/models.py
+++ b/genesis_core/node/machine/dm/models.py
@@ -21,7 +21,7 @@ from genesis_core.node.dm import models
 
 
 class Machine(models.Machine, models.CastToBaseMixin):
-    __cast_filels__ = ("node", "pool")
+    __cast_fields__ = ("node", "pool")
 
     node = relationships.relationship(models.Node, prefetch=True)
     pool = relationships.relationship(models.MachinePool, prefetch=True)

--- a/genesis_core/node/scheduler/driver/base.py
+++ b/genesis_core/node/scheduler/driver/base.py
@@ -45,3 +45,26 @@ class MachinePoolAbstractWeighter(abc.ABC):
         1 means the pool is the best for the node.
         0 means the pool is the worst for the node.
         """
+
+
+class MachineAbstractFilter(abc.ABC):
+
+    def filter(
+        self,
+        node: models.Node,
+        machines: tp.List[models.Machine],
+    ) -> tp.Iterable[models.Machine]:
+        """Filter out machines that are not suitable for the node."""
+
+
+class MachineAbstractWeighter(abc.ABC):
+    def weight(
+        self,
+        machines: tp.List[models.MachinePool],
+    ) -> tp.Iterable[float]:
+        """Assign weights to machines.
+
+        Every machine gets a weight from range [0, 1].
+        1 means the machine is the best for the node.
+        0 means the machine is the worst for the node.
+        """

--- a/genesis_core/node/scheduler/driver/filters/available.py
+++ b/genesis_core/node/scheduler/driver/filters/available.py
@@ -33,3 +33,17 @@ class CoresRamAvailableFilter(base.MachinePoolAbstractFilter):
             for p in pools
             if p.avail_cores >= machine.cores and p.avail_ram >= machine.ram
         )
+
+
+class HWCoresRamAvailableFilter(base.MachineAbstractFilter):
+
+    def filter(
+        self,
+        node: models.Node,
+        machines: tp.Iterable[models.Machine],
+    ) -> tp.Iterable[models.Machine]:
+        """Filter out machines that are not suitable for the node."""
+
+        return tuple(
+            m for m in machines if m.cores >= node.cores and m.ram >= node.ram
+        )

--- a/genesis_core/orch_api/api/routes.py
+++ b/genesis_core/orch_api/api/routes.py
@@ -39,10 +39,41 @@ class NodeRoute(routes.Route):
     __controller__ = controllers.NodesController
 
 
+class InterfacesRoute(routes.Route):
+    """Handler for /v1/machines/<id>/interfaces/ endpoint"""
+
+    __controller__ = controllers.InterfacesController
+
+
 class MachineRoute(routes.Route):
     """Handler for /v1/machines/ endpoint"""
 
     __controller__ = controllers.MachinesController
+
+    interfaces = routes.route(InterfacesRoute, resource_route=True)
+
+
+class CoreAgentGetPayloadAction(routes.Action):
+    """Handler for /v1/core_agents/<uuid>/actions/get_payload endpoint"""
+
+    __controller__ = controllers.CoreAgentController
+
+
+class CoreAgentRegisterPayloadAction(routes.Action):
+    """Handler for /v1/core_agents/<uuid>/actions/register_payload/invoke endpoint"""
+
+    __controller__ = controllers.CoreAgentController
+
+
+class CoreAgentRoute(routes.Route):
+    """Handler for /v1/core_agents/ endpoint"""
+
+    __controller__ = controllers.CoreAgentController
+
+    get_payload = routes.action(CoreAgentGetPayloadAction)
+    register_payload = routes.action(
+        CoreAgentRegisterPayloadAction, invoke=True
+    )
 
 
 class ApiEndpointRoute(routes.Route):
@@ -55,3 +86,4 @@ class ApiEndpointRoute(routes.Route):
     boots = routes.route(NetbootRoute)
     nodes = routes.route(NodeRoute)
     machines = routes.route(MachineRoute)
+    core_agents = routes.route(CoreAgentRoute)

--- a/genesis_core/orch_api/dm/models.py
+++ b/genesis_core/orch_api/dm/models.py
@@ -15,15 +15,25 @@
 #    under the License.
 from __future__ import annotations
 
-from restalchemy.dm import types
+import json
+import hashlib
+import datetime
+import typing as tp
+import uuid as sys_uuid
 
-from genesis_core.node.dm import models as node_models
+from restalchemy.dm import types
+from restalchemy.dm import relationships
+from restalchemy.storage.sql import engines
+from restalchemy.dm import filters as dm_filters
+from restalchemy.common import exceptions as ra_common_exc
+
+from genesis_core.node.dm import models
 
 LOCAL_GC_HOST = "localhost"
 LOCAL_GC_PORT = 11011
 
 
-class Netboot(node_models.Netboot):
+class Netboot(models.Netboot):
     __custom_properties__ = {
         "gc_host": types.String(max_length=255),
         "gc_port": types.Integer(),
@@ -76,9 +86,167 @@ class Netboot(node_models.Netboot):
         self.initrd = initrd
 
 
-class Node(node_models.Node):
-    pass
+class Node(models.Node):
+
+    @classmethod
+    def get_state(cls, uuid: sys_uuid.UUID) -> tp.Dict[str, tp.Any]:
+        node = cls.objects.get_one(filters={"uuid": dm_filters.EQ(str(uuid))})
+        ports = models.Port.objects.get_all(
+            filters={"node": dm_filters.EQ(str(uuid))}
+        )
+        return {
+            "node": node.dump_to_simple_view(),
+            "ports": [p.dump_to_simple_view() for p in ports],
+        }
 
 
-class Machine(node_models.Machine):
-    pass
+class Machine(models.Machine):
+
+    @classmethod
+    def from_agent_payload(cls, payload: tp.Dict[str, tp.Any]) -> "Machine":
+        if "machine" not in payload:
+            raise ValueError("Machine not found in payload")
+
+        return cls.restore_from_simple_view(**payload["machine"])
+
+
+class Interface(models.Interface):
+    machine = relationships.relationship(Machine, prefetch=True)
+
+    @classmethod
+    def from_agent_payload(
+        cls, machine: Machine, payload: tp.Dict[str, tp.Any]
+    ) -> tp.List["Interface"]:
+        interfaces = []
+
+        for iface in payload.get("interfaces", ()):
+            i = cls.restore_from_simple_view(machine=machine, **iface)
+            interfaces.append(i)
+
+        return interfaces
+
+
+class CoreAgent(models.CoreAgent):
+
+    machine = relationships.relationship(Machine, prefetch=True)
+
+    @classmethod
+    def calculate_payload_hash(cls, payload: tp.Dict[str, tp.Any]) -> str:
+        """Calculate payload hash using dedicated fields."""
+        m = hashlib.sha256()
+        data = {}
+
+        # Base payload object
+        if machine := payload.get("machine"):
+            data = {
+                "machine": {
+                    "image": machine["image"],
+                    "node": machine.get("node"),
+                }
+            }
+
+        if node := payload.get("node"):
+            data["node"] = {
+                "cores": node["cores"],
+                "ram": node["ram"],
+                "node_type": node["node_type"],
+                "image": node["image"],
+            }
+
+        if interfaces := payload.get("interfaces"):
+            data["interfaces"] = [
+                {
+                    "mac": iface["mac"],
+                    "ipv4": iface["ipv4"],
+                    "mask": iface["mask"],
+                }
+                for iface in interfaces
+            ]
+
+        m.update(json.dumps(data, separators=(",", ":")).encode("utf-8"))
+        return m.hexdigest()
+
+    def _get_payload(self) -> tp.Dict[str, tp.Any]:
+        state = {
+            "payload_updated_at": self.payload_updated_at.isoformat(),
+            "machine": self.machine.dump_to_simple_view(),
+        }
+
+        if self.machine.node:
+            node_state = Node.get_state(self.machine.node)
+            state.update(node_state)
+
+        interfaces = models.Interface.objects.get_all(
+            filters={"machine": dm_filters.EQ(str(self.machine.uuid))}
+        )
+        state["interfaces"] = [i.dump_to_simple_view() for i in interfaces]
+
+        state["payload_hash"] = self.calculate_payload_hash(state)
+        return state
+
+    def _get_short_payload(self, payload_hash: str) -> tp.Dict[str, tp.Any]:
+        state = {
+            "payload_updated_at": self.payload_updated_at.isoformat(),
+            "payload_hash": payload_hash,
+        }
+
+        return state
+
+    def get_payload(
+        self,
+        payload_hash: str = "",
+        payload_updated_at: datetime.datetime | None = None,
+    ) -> tp.Dict[str, tp.Any]:
+        # The agent has state. Check if the state has changed
+        latest_updated_at = self.latest_updated_at()
+
+        # Rely on the latest_updated_at
+        if payload_updated_at == latest_updated_at:
+            return self._get_short_payload(payload_hash)
+
+        # The agent and system states are different.
+        # Firstly get the state then update the payload_updated_at.
+        state = self._get_payload()
+        state["payload_updated_at"] = latest_updated_at.isoformat()
+        self.payload_updated_at = latest_updated_at
+        self.update()
+
+        return state
+
+    def latest_updated_at(self) -> datetime.datetime:
+        payload_expression = (
+            "SELECT MAX(max) AS latest_updated_at "
+            "FROM ("
+            "    SELECT MAX(updated_at) FROM nodes WHERE uuid = %s "
+            "    UNION ALL "
+            "    SELECT MAX(updated_at) FROM machines WHERE node = %s "
+            "    UNION ALL "
+            "    SELECT MAX(updated_at) FROM compute_ports WHERE node = %s "
+            ");"
+        )
+        machine_expression = (
+            "SELECT MAX(max) AS latest_updated_at "
+            "FROM ("
+            "    SELECT MAX(updated_at) FROM machines WHERE uuid = %s "
+            "    UNION ALL "
+            "    SELECT MAX(updated_at) FROM compute_ports WHERE machine = %s "
+            ");"
+        )
+        if self.machine is None:
+            raise ra_common_exc.CanNotFindResourceByModel(model=self)
+
+        if self.machine.node is None:
+            expression = machine_expression
+            params = [str(self.uuid)] * 2
+        else:
+            expression = payload_expression
+            params = [str(self.machine.node)] * 3
+
+        engine = engines.engine_factory.get_engine()
+        with engine.session_manager() as session:
+            curs = session.execute(expression, params)
+            latest_updated_at = curs.fetchone()["latest_updated_at"]
+            latest_updated_at = latest_updated_at.replace(
+                tzinfo=datetime.timezone.utc
+            )
+            return latest_updated_at

--- a/genesis_core/tests/functional/conftest.py
+++ b/genesis_core/tests/functional/conftest.py
@@ -365,7 +365,9 @@ def pool_factory():
         **kwargs,
     ) -> tp.Dict[str, tp.Any]:
         uuid = uuid or sys_uuid.uuid4()
-        driver_spec = driver_spec or {"driver": "libvirt"}
+        driver_spec = (
+            {"driver": "libvirt"} if driver_spec is None else driver_spec
+        )
         pool = node_models.MachinePool(
             uuid=uuid,
             agent=agent,
@@ -430,6 +432,25 @@ def builder_factory() -> tp.Callable:
             **kwargs,
         )
         view = builder.dump_to_simple_view()
+        return view
+
+    return factory
+
+
+@pytest.fixture
+def interface_factory() -> tp.Callable:
+    def factory(
+        uuid: sys_uuid.UUID | None = None,
+        mac: str | None = None,
+        **kwargs,
+    ) -> tp.Dict[str, tp.Any]:
+        uuid = uuid or sys_uuid.uuid4()
+        interface = node_models.Interface(
+            uuid=uuid,
+            mac=mac or node_models.Port.generate_mac(),
+            **kwargs,
+        )
+        view = interface.dump_to_simple_view()
         return view
 
     return factory

--- a/genesis_core/tests/functional/restapi/test_node_orch_api.py
+++ b/genesis_core/tests/functional/restapi/test_node_orch_api.py
@@ -19,10 +19,12 @@ import uuid as sys_uuid
 from urllib.parse import urljoin
 
 import pytest
+import netaddr
 import requests
 from oslo_config import cfg
 
 from genesis_core.node.dm import models
+from genesis_core.common import constants as c
 from genesis_core.tests.functional import utils as test_utils
 from genesis_core.tests.functional import conftest
 from genesis_core.orch_api.api import app as orch_app
@@ -121,3 +123,293 @@ class TestNodeOrchApi:
         assert "tftp://" not in response.text
         assert "https://kernel.org/vmlinuz" in response.text
         assert "https://kernel.org/initrd.img" in response.text
+
+    def test_simple_core_agent(
+        self,
+        machine_factory: tp.Callable,
+        default_pool: tp.Dict[str, tp.Any],
+        orch_api: test_utils.RestServiceTestCase,
+    ):
+        uuid = sys_uuid.uuid4()
+        machine = machine_factory(
+            boot="hd0",
+            uuid=uuid,
+            firmware_uuid=uuid,
+            pool=sys_uuid.UUID(default_pool["uuid"]),
+        )
+        pool = models.MachinePool.restore_from_simple_view(**default_pool)
+        pool.insert()
+
+        machine = models.Machine.restore_from_simple_view(**machine)
+        machine.insert()
+
+        agent = models.CoreAgent(uuid=machine.uuid)
+        agent.insert()
+
+        url = urljoin(orch_api.base_url, f"core_agents/{agent.uuid}")
+
+        response = requests.get(url)
+        output = response.json()
+
+        assert response.status_code == 200
+        assert output["uuid"] == str(agent.uuid)
+        assert (
+            output["payload_updated_at"][:10]
+            == str(agent.payload_updated_at)[:10]
+        )
+
+    def test_core_agent_get_payload(
+        self,
+        machine_factory: tp.Callable,
+        default_pool: tp.Dict[str, tp.Any],
+        orch_api: test_utils.RestServiceTestCase,
+    ):
+        uuid = sys_uuid.uuid4()
+        machine = machine_factory(
+            boot="hd0",
+            uuid=uuid,
+            firmware_uuid=uuid,
+            pool=sys_uuid.UUID(default_pool["uuid"]),
+        )
+        pool = models.MachinePool.restore_from_simple_view(**default_pool)
+        pool.insert()
+
+        machine = models.Machine.restore_from_simple_view(**machine)
+        machine.insert()
+
+        agent = models.CoreAgent(uuid=machine.uuid, machine=machine.uuid)
+        agent.insert()
+
+        url = urljoin(
+            orch_api.base_url, f"core_agents/{agent.uuid}/actions/get_payload"
+        )
+        data = {
+            "payload_updated_at": agent.payload_updated_at.isoformat(),
+        }
+
+        response = requests.get(url, json=data)
+        output = response.json()
+
+        assert response.status_code == 200
+        assert output["payload_hash"]
+        assert "machine" in output
+        assert (
+            output["payload_updated_at"]
+            != agent.payload_updated_at.isoformat()
+        )
+
+    def test_core_agent_payload_already_actual(
+        self,
+        machine_factory: tp.Callable,
+        default_pool: tp.Dict[str, tp.Any],
+        orch_api: test_utils.RestServiceTestCase,
+    ):
+        uuid = sys_uuid.uuid4()
+        machine = machine_factory(
+            boot="hd0",
+            uuid=uuid,
+            firmware_uuid=uuid,
+            pool=sys_uuid.UUID(default_pool["uuid"]),
+        )
+        pool = models.MachinePool.restore_from_simple_view(**default_pool)
+        pool.insert()
+
+        machine = models.Machine.restore_from_simple_view(**machine)
+        machine.insert()
+
+        agent = models.CoreAgent(uuid=machine.uuid, machine=machine.uuid)
+        agent.insert()
+
+        url = urljoin(
+            orch_api.base_url, f"core_agents/{agent.uuid}/actions/get_payload"
+        )
+        data = {
+            "payload_updated_at": agent.payload_updated_at.isoformat(),
+        }
+
+        response = requests.get(url, json=data)
+        output = response.json()
+
+        assert response.status_code == 200
+        assert "machine" in output
+        assert (
+            output["payload_updated_at"]
+            != agent.payload_updated_at.isoformat()
+        )
+
+        # The second call should return the same state
+        payload_updated_at = output["payload_updated_at"]
+        payload_hash = output["payload_hash"]
+        data = {
+            "payload_updated_at": payload_updated_at,
+            "payload_hash": payload_hash,
+        }
+
+        response = requests.get(url, json=data)
+        output = response.json()
+
+        assert response.status_code == 200
+        assert output["payload_updated_at"] == payload_updated_at
+        assert output["payload_hash"] == payload_hash
+        assert "machine" not in output
+
+    def test_core_agent_register_payload(
+        self,
+        machine_factory: tp.Callable,
+        pool_factory: tp.Callable,
+        orch_api: test_utils.RestServiceTestCase,
+    ):
+        uuid = sys_uuid.uuid4()
+        machine = machine_factory(
+            uuid=uuid,
+            firmware_uuid=uuid,
+            machine_type="HW",
+        )
+        machine["pool"] = None
+
+        # HW machine pool
+        hw_pool = pool_factory(
+            machine_type="HW",
+            driver_spec={},
+        )
+        hw_pool = models.MachinePool.restore_from_simple_view(**hw_pool)
+        hw_pool.insert()
+
+        agent = models.CoreAgent(uuid=uuid)
+        agent.insert()
+
+        url = urljoin(
+            orch_api.base_url,
+            f"core_agents/{agent.uuid}/actions/register_payload/invoke",
+        )
+
+        data = {
+            "machine": machine,
+            "node": None,
+            "interfaces": [
+                {
+                    "name": "eth0",
+                    "mac": "00:1A:2B:3C:4D:5E",
+                    "ipv4": "10.0.0.1",
+                    "mask": "255.255.255.0",
+                    "mtu": 1500,
+                }
+            ],
+        }
+
+        response = requests.post(url, json=data)
+
+        assert response.status_code == 200
+
+        agent = models.CoreAgent.objects.get_one()
+        machine = models.Machine.objects.get_one()
+        # port = models.Port.objects.get_one()
+        nodes = models.Node.objects.get_all()
+        interface = models.Interface.objects.get_one()
+
+        assert agent.machine == machine.uuid
+        assert interface.ipv4 == netaddr.IPAddress("10.0.0.1")
+        assert interface.mask == netaddr.IPAddress("255.255.255.0")
+        assert interface.mac == "00:1A:2B:3C:4D:5E"
+        assert interface.machine == machine.uuid
+        assert len(nodes) == 0
+
+    def test_machine_interfaces(
+        self,
+        machine_factory: tp.Callable,
+        pool_factory: tp.Callable,
+        orch_api: test_utils.RestServiceTestCase,
+    ):
+        uuid = sys_uuid.uuid4()
+        machine = machine_factory(
+            uuid=uuid,
+            firmware_uuid=uuid,
+            machine_type="HW",
+        )
+        machine["pool"] = None
+
+        # HW machine pool
+        hw_pool = pool_factory(
+            machine_type="HW",
+            driver_spec={},
+        )
+        hw_pool = models.MachinePool.restore_from_simple_view(**hw_pool)
+        hw_pool.insert()
+
+        agent = models.CoreAgent(uuid=uuid)
+        agent.insert()
+
+        url = urljoin(
+            orch_api.base_url,
+            f"core_agents/{agent.uuid}/actions/register_payload/invoke",
+        )
+
+        data = {
+            "machine": machine,
+            "node": None,
+            "interfaces": [
+                {
+                    "name": "eth0",
+                    "mac": "00:1A:2B:3C:4D:5E",
+                    "ipv4": "10.0.0.1",
+                    "mask": "255.255.255.0",
+                    "mtu": 1500,
+                }
+            ],
+        }
+
+        response = requests.post(url, json=data)
+        assert response.status_code == 200
+
+        interface = models.Interface.objects.get_one()
+        assert interface.mac == "00:1A:2B:3C:4D:5E"
+        assert str(interface.ipv4) == "10.0.0.1"
+        assert str(interface.mask) == "255.255.255.0"
+        assert interface.mtu == 1500
+
+    def test_core_agent_register_payload_vm(
+        self,
+        machine_factory: tp.Callable,
+        default_pool: tp.Dict[str, tp.Any],
+        orch_api: test_utils.RestServiceTestCase,
+    ):
+        uuid = sys_uuid.uuid4()
+        machine = machine_factory(
+            boot="hd0",
+            uuid=uuid,
+            firmware_uuid=uuid,
+            pool=sys_uuid.UUID(default_pool["uuid"]),
+        )
+        pool = models.MachinePool.restore_from_simple_view(**default_pool)
+        pool.insert()
+
+        machine = models.Machine.restore_from_simple_view(**machine)
+        machine.insert()
+
+        agent = models.CoreAgent(uuid=machine.uuid, machine=machine.uuid)
+        agent.insert()
+
+        url = urljoin(
+            orch_api.base_url,
+            f"core_agents/{agent.uuid}/actions/register_payload/invoke",
+        )
+
+        data = {
+            "machine": machine.dump_to_simple_view(),
+            "node": None,
+            "interfaces": [
+                {
+                    "name": "eth0",
+                    "mac": "00:1A:2B:3C:4D:5E",
+                    "ipv4": "10.0.0.1",
+                    "mask": "255.255.255.0",
+                    "mtu": 1500,
+                }
+            ],
+        }
+
+        response = requests.post(url, json=data)
+        assert response.status_code == 200
+
+        machine = models.Machine.objects.get_one()
+        assert machine.machine_type == "VM"

--- a/migrations/0017-core-agent-4b8026.py
+++ b/migrations/0017-core-agent-4b8026.py
@@ -1,0 +1,161 @@
+# Copyright 2016 Eugene Frolov <eugene@frolov.net.ru>
+# Copyright 2025 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import migrations
+
+
+class MigrationStep(migrations.AbstarctMigrationStep):
+
+    def __init__(self):
+        self._depends = ["0016-add-permissions-to-all-iam-resources-3b82c6.py"]
+
+    @property
+    def migration_id(self):
+        return "4b802612-3c27-4174-8133-be26a0a05fdb"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        sql_expressions = [
+            # TABLES
+            """
+            CREATE TABLE IF NOT EXISTS compute_core_agents (
+                uuid UUID NOT NULL PRIMARY KEY,
+                name varchar(255) NOT NULL,
+                description varchar(255) NOT NULL,
+                node UUID references nodes(uuid) ON DELETE SET NULL,
+                machine UUID references machines(uuid) ON DELETE CASCADE NULL DEFAULT NULL,
+                payload_updated_at timestamp NOT NULL
+            );
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS compute_core_agents_node_id_idx
+                ON compute_core_agents (node);
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS compute_core_agents_machine_id_idx
+                ON compute_core_agents (machine);
+            """,
+            """
+            ALTER TABLE compute_subnets 
+                ADD IF NOT EXISTS ip_discovery_range varchar(31) NULL DEFAULT NULL;
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS compute_net_interfaces (
+                uuid UUID NOT NULL PRIMARY KEY,
+                name varchar(255) NOT NULL,
+                description varchar(255) NOT NULL,
+                machine UUID references machines(uuid) ON DELETE CASCADE,
+                ipv4 varchar(15) NULL DEFAULT NULL,
+                mask varchar(15) NULL DEFAULT NULL,
+                mac varchar(17) NULL DEFAULT NULL,
+                mtu integer DEFAULT 1500,
+                created_at timestamp NOT NULL DEFAULT current_timestamp,
+                updated_at timestamp NOT NULL DEFAULT current_timestamp
+            );
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS compute_net_interfaces_machine_id_idx
+                ON compute_net_interfaces (machine);
+            """,
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS compute_net_interfaces_mac_machine_id_idx
+                ON compute_ports (mac, machine);
+            """,
+            # Views
+            """
+            DROP VIEW IF EXISTS unscheduled_nodes;
+            """,
+            """
+            CREATE OR REPLACE VIEW unscheduled_nodes AS
+                SELECT
+                    nodes.uuid as uuid,
+                    nodes.uuid as node
+                FROM nodes LEFT JOIN machines ON 
+                    nodes.uuid = machines.node WHERE machines.uuid is NULL;
+            """,
+            """
+            CREATE OR REPLACE VIEW compute_hw_nodes_without_ports AS
+                SELECT
+                    nodes.uuid as uuid,
+                    nodes.uuid as node,
+                    machines.uuid as machine,
+                    compute_net_interfaces.uuid as iface
+                FROM nodes LEFT JOIN machines ON 
+                    nodes.uuid = machines.node
+                LEFT JOIN compute_net_interfaces ON
+                    compute_net_interfaces.machine = machines.uuid
+                LEFT JOIN compute_ports ON
+                    compute_ports.node = nodes.uuid
+                WHERE nodes.node_type = 'HW' AND machines.uuid is not NULL AND compute_net_interfaces.ipv4 is not NULL AND compute_ports.uuid is NULL;
+            """,
+        ]
+
+        for expr in sql_expressions:
+            session.execute(expr, None)
+
+    def downgrade(self, session):
+        sql_expressions = [
+            """
+            ALTER TABLE compute_subnets 
+                DROP COLUMN IF EXISTS ip_discovery_range;
+            """,
+            """
+            DROP VIEW IF EXISTS unscheduled_nodes;
+            """,
+            """
+            CREATE OR REPLACE VIEW unscheduled_nodes AS
+                SELECT
+                    nodes.uuid,
+                    nodes.project_id,
+                    nodes.name,
+                    nodes.description,
+                    nodes.cores,
+                    nodes.ram,
+                    nodes.image,
+                    nodes.node_type,
+                    nodes.status,
+                    nodes.created_at,
+                    nodes.updated_at,
+                    nodes.root_disk_size,
+                    nodes.default_network
+                FROM nodes LEFT JOIN machines ON 
+                    nodes.uuid = machines.node WHERE machines.uuid is NULL;
+            """,
+        ]
+
+        tables = [
+            "compute_net_interfaces",
+            "compute_core_agents",
+        ]
+        views = [
+            "compute_hw_nodes_without_ports",
+        ]
+
+        for view_name in views:
+            self._delete_view_if_exists(session, view_name)
+
+        for expr in sql_expressions:
+            session.execute(expr, None)
+
+        for table_name in tables:
+            self._delete_table_if_exists(session, table_name)
+
+
+migration_step = MigrationStep()


### PR DESCRIPTION
Main focus in this change is the basic baremetal support. But also a log
of other many improvements are introduced. Main of them are:

- First implementation of Status API for Core agents. Core agents is
  able to register thier `payloads` and actualize them during life
  cycle.
- Default HW machine pool. All new baremetal nodes are added to this
  pool after if the follow the auto discovery procedure.
- Auto discovery IP range. To support the auto discovery procedure for
  baremetal nodes.
- Reworked machine scheduling logic. Scheduler filters and weighers for machines
  were added.