### PR TITLE
Custom routes for ISC DHCP server

### DIFF
--- a/genesis/images/startup_cfg.yaml
+++ b/genesis/images/startup_cfg.yaml
@@ -11,5 +11,7 @@ startup_entities:
           cidr: "10.20.0.0/22"
           ip_range: "10.20.0.20-10.20.0.200"
           dns_servers: ["8.8.8.8"]
-          routers: ["10.20.0.1"]
+          routers:
+            - to: "0.0.0.0/0"
+              via: "10.20.0.1"
           next_server: "10.20.0.2"

--- a/genesis_core/node/dm/models.py
+++ b/genesis_core/node/dm/models.py
@@ -401,7 +401,14 @@ class Subnet(
     )
     routers = properties.property(
         types.AllowNone(
-            types.TypedList(types.String(min_length=1, max_length=128))
+            types.TypedList(
+                types.SchemeDict(
+                    {
+                        "to": types_net.Network(),
+                        "via": types_net.IPAddress(),
+                    }
+                )
+            )
         ),
         default=lambda: [],
     )


### PR DESCRIPTION
Added an ability to specify custom routes for isc-dhcp server. To specify the custom routes is used `rfc3442-classless-static-routes` directive:

https://datatracker.ietf.org/doc/html/rfc3442

In the startup file we need to specify something like this:
```
  - to: "0.0.0.0/0"
    via: "10.20.0.1"
  - to: "10.20.1.0/24"
    via: "10.20.0.3"
```

It will be translated into the following line in the dhcp configuration.
```
option rfc3442-classless-static-routes 24, 10,20,1, 10,20,0,3, 0, 10,20,0,1;
```