### PR TITLE
Hotfix: Ignore out of IP range addresses for IPAM

### DIFF
--- a/genesis_core/network/ipam.py
+++ b/genesis_core/network/ipam.py
@@ -108,7 +108,16 @@ class Ipam:
                 address_pool.insert(i + 1, (address + 1, e))
                 return
 
-        raise IpamIpNotFound(ip=netaddr.IPAddress(address))
+        # FIXME(akremenetsky): The original implementation raises
+        # an exception here:
+        # ```
+        # raise IpamIpNotFound(ip=netaddr.IPAddress(address))
+        # ```
+        # But we already have installations where IPs of some nodes
+        # are out of range of chosen IPs. It's a problem since occupied
+        # cannot be calculated correctly. Therefore we just log it and do
+        # nothing. Perhaps we should raise an exception in the future.
+        LOG.warning("IP %s is not in the pool", address)
 
     def allocate_ip(
         self,

--- a/genesis_core/tests/unit/compute/test_ipam.py
+++ b/genesis_core/tests/unit/compute/test_ipam.py
@@ -46,11 +46,13 @@ class TestIPAM:
         empty_ipam.occupy_ip(0, address_pool)
         assert address_pool == []
 
-    def test_occupy_not_in_pool(self, empty_ipam: ipam.Ipam):
-        address_pool = [(0, 10)]
-        with pytest.raises(ipam.IpamIpNotFound) as e:
-            empty_ipam.occupy_ip(20, address_pool)
-            assert e.ip == netaddr.IPAddress("0.0.0.20")
+    # Disable because of:
+    # https://github.com/infraguys/genesis_core/pull/52
+    # def test_occupy_not_in_pool(self, empty_ipam: ipam.Ipam):
+    #     address_pool = [(0, 10)]
+    #     with pytest.raises(ipam.IpamIpNotFound) as e:
+    #         empty_ipam.occupy_ip(20, address_pool)
+    #         assert e.ip == netaddr.IPAddress("0.0.0.20")
 
     def test_allocate_ip(self, empty_ipam: ipam.Ipam):
         subnet = list(empty_ipam._pool_map.keys())[0]


### PR DESCRIPTION
Originally we raise an exception for these cases but we already have installations where IPs of some nodes are out of range of chosen IPs. It's a problem since occupied cannot be calculated correctly. Therefore we just log it and do nothing. Perhaps we should raise an exception in the future.