### PR TITLE
Hotfix: Added event_type_mapping file to etc at build time

### DIFF
--- a/etc/genesis_core/event_type_mapping.yaml
+++ b/etc/genesis_core/event_type_mapping.yaml
@@ -1,3 +1,3 @@
 EventTypeMapping:
     IamUserRegistration: b963bcfe-0a99-11f0-916d-047c160cda6f  # genesis_core/events/constants.py:IAM_USER_REGISTRATION_EVENT
-    ResetPassword: "df5ac4b0-de7e-41d5-a0bc-6e26bf35594a"
+    IamUserResetPassword: "df5ac4b0-de7e-41d5-a0bc-6e26bf35594a"

--- a/genesis/images/install.sh
+++ b/genesis/images/install.sh
@@ -66,6 +66,7 @@ sudo -u postgres psql -c "CREATE DATABASE $GC_PG_USER OWNER $GC_PG_DB;"
 sudo mkdir -p $GC_CFG_DIR
 sudo cp "$GC_PATH/etc/genesis_core/genesis_core.conf" $GC_CFG_DIR/
 sudo cp "$GC_PATH/etc/genesis_core/logging.yaml" $GC_CFG_DIR/
+sudo cp "$GC_PATH/etc/genesis_core/event_type_mapping.yaml" $GC_CFG_DIR/
 sudo cp "$GC_PATH/genesis/images/startup_cfg.yaml" $GC_CFG_DIR/
 sudo cp "$GC_PATH/genesis/images/bootstrap.sh" $BOOTSTRAP_PATH/0100-gc-bootstrap.sh
 python3 -m uuid | sudo tee /var/lib/genesis/node-id


### PR DESCRIPTION
The core services aren't run without the hotfix for fresh builds.
```
ubuntu@ubuntu:~$ journalctl -u gc-user-api.service -f
May 15 19:30:49 ubuntu gc-user-api[901]:     return EVENT_CLIENT_MAPPER[client_type](conf=conf)
May 15 19:30:49 ubuntu gc-user-api[901]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
May 15 19:30:49 ubuntu gc-user-api[901]:   File "/opt/genesis_core/.venv/lib/python3.12/site-packages/gcl_sdk/events/clients.py", line 55, in build_from_config
May 15 19:30:49 ubuntu gc-user-api[901]:     with open(config_file) as fp:
May 15 19:30:49 ubuntu gc-user-api[901]:          ^^^^^^^^^^^^^^^^^
May 15 19:30:49 ubuntu gc-user-api[901]: TypeError: expected str, bytes or os.PathLike object, not NoneType
May 15 19:30:49 ubuntu systemd[1]: gc-user-api.service: Main process exited, code=exited, status=1/FAILURE
May 15 19:30:49 ubuntu systemd[1]: gc-user-api.service: Failed with result 'exit-code'.
May 15 19:30:55 ubuntu systemd[1]: gc-user-api.service: Scheduled restart job, restart counter is at 1.
May 15 19:30:55 ubuntu systemd[1]: Starting gc-user-api.service - Genesis Core User API...
May 15 19:30:57 ubuntu systemd[1]: Started gc-user-api.service - Genesis Core User API.
```