### PR TITLE
"username" field added to User response body

### DIFF
--- a/genesis_core/tests/functional/restapi/iam/test_users.py
+++ b/genesis_core/tests/functional/restapi/iam/test_users.py
@@ -376,6 +376,7 @@ class TestUsers(base.BaseIamResourceTest):
         user_has_only_fields = [
             "uuid",
             "name",
+            "username",
             "description",
             "created_at",
             "updated_at",

--- a/genesis_core/user_api/iam/dm/models.py
+++ b/genesis_core/user_api/iam/dm/models.py
@@ -210,7 +210,8 @@ class User(
     def get_response_body(self):
         return {
             "uuid": str(self.uuid),
-            "name": self.name,
+            "name": self.name,  # deprecated, use "username"
+            "username": self.name,
             "first_name": self.first_name,
             "last_name": self.last_name,
             "email": self.email,
@@ -943,6 +944,9 @@ class MeInfo:
         user = self._user.get_storable_snapshot()
         for drop_field in skip_fields:
             user.pop(drop_field, None)
+
+        # "name" field is deprecated and will be removed, use "username"
+        user["username"] = user["name"]
 
         organizations = []
         for organization in Organization.list_my():


### PR DESCRIPTION
For consistency with incoming data schema, that now has a `username→name` mapping.
It duplicates `name` field data, i.e. both fields get data from `User.name`
`name` field is deprecated now, temporarily left for backwards compatibility.