### PR TITLE
Fix for InvalidGrantType

### DIFF
--- a/genesis_core/common/api/middlewares/errors.py
+++ b/genesis_core/common/api/middlewares/errors.py
@@ -32,6 +32,7 @@ class ErrorsHandlerMiddleware(middlewares.ErrorsHandlerMiddleware):
     )
     valid_exc = middlewares.ErrorsHandlerMiddleware.valid_exc + (
         ra_e.TypeError,
+        common_exc.CommonValueErrorException,
     )
 
     def _construct_error_response(self, req, e):

--- a/genesis_core/tests/functional/restapi/iam/test_clients.py
+++ b/genesis_core/tests/functional/restapi/iam/test_clients.py
@@ -397,3 +397,12 @@ class TestClients(base.BaseIamResourceTest):
                     "scope": "project:859aaa4f-9fcb-4433-8bc0-a84232a1177f",
                 },
             )
+
+    def test_invalid_grant_type_error(self, user_api_client, auth_test1_user):
+        client = user_api_client(auth_test1_user)
+
+        with pytest.raises(bazooka_exc.BadRequestError):
+            client.post(
+                url=auth_test1_user.get_token_url(endpoint=client.endpoint),
+                data={"grant_type": "obviously invalid"},
+            )

--- a/genesis_core/user_api/iam/exceptions.py
+++ b/genesis_core/user_api/iam/exceptions.py
@@ -168,3 +168,10 @@ class CanNotDeleteIamClient(
         "The current user is not permitted to delete IAM client `{uuid}`."
         " This action requires the `{rule}`, which has not been granted."
     )
+
+
+class InvalidGrantType(
+    exceptions.CommonValueErrorException,
+    iam_exc.InvalidGrantTypeError,
+):
+    __template__ = "Invalid grant type: {grant_type}"


### PR DESCRIPTION
`AttributeError: module 'genesis_core.user_api.iam.exceptions' has no attribute 'InvalidGrantType'.`