### PR TITLE
Email lowercase index added to the migrations

### DIFF
--- a/migrations/0027-email-lowercase-unique-constraint-98a7bb.py
+++ b/migrations/0027-email-lowercase-unique-constraint-98a7bb.py
@@ -1,0 +1,50 @@
+# Copyright 2016 Eugene Frolov <eugene@frolov.net.ru>
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import migrations
+
+
+class MigrationStep(migrations.AbstarctMigrationStep):
+
+    def __init__(self):
+        self._depends = ["0026-case-insensitive-users-name-index-41f4b9.py"]
+
+    @property
+    def migration_id(self):
+        return "98a7bbb6-9b39-4d58-9e10-b64914790fbb"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        expression = """
+            DROP INDEX IF EXISTS iam_users_email_idx;
+            CREATE UNIQUE INDEX iam_users_email_lower_idx ON iam_users (
+                LOWER(email)
+            );
+        """
+        session.execute(expression)
+
+    def downgrade(self, session):
+        expression = """
+            DROP INDEX IF EXISTS iam_users_email_lower_idx;
+            CREATE UNIQUE INDEX iam_users_email_idx ON iam_users (email);
+        """
+        session.execute(expression)
+
+
+migration_step = MigrationStep()


### PR DESCRIPTION
Replaced usual non-lowercase one.
Needed since we check for email uniqueness by looking for `LOWER(email)` in the iam table.