### PR TITLE
Excluded dev, build or test directories at image build

### DIFF
--- a/genesis/genesis.yaml
+++ b/genesis/genesis.yaml
@@ -8,6 +8,12 @@ build:
       # Local path
       path:
         src: ../../genesis_core
+      exclude:
+        - .venv
+        - .tox
+        - .pytest_cache
+        - build
+        - cover
 
     # Network configuration
     - dst: /etc/netplan/90-genesis-net-base-config.yaml


### PR DESCRIPTION
Excluded directories we don't need in the image even for the development purposes.

**NOTE:** genesis-devtools>=0.3.0 is required.