### PR TITLE
Keep user.confirmation_code on subsequent resets if its still valid

### DIFF
--- a/genesis_core/tests/functional/restapi/iam/test_users.py
+++ b/genesis_core/tests/functional/restapi/iam/test_users.py
@@ -279,7 +279,7 @@ class TestUsers(base.BaseIamResourceTest):
             filters={"uuid": auth_test1_user.uuid}
         )
         user.email_verified = False
-        user.reset_confirmation_code()
+        user.create_confirmation_code()
         user.save()
 
         client = user_api_noauth_client()
@@ -326,7 +326,7 @@ class TestUsers(base.BaseIamResourceTest):
             filters={"uuid": auth_test1_user.uuid}
         )
         user.email_verified = False
-        user.reset_confirmation_code()
+        user.create_confirmation_code()
         user.confirmation_code_made_at = code_made_at
         user.save()
 

--- a/genesis_core/tests/functional/service/test_janitor.py
+++ b/genesis_core/tests/functional/service/test_janitor.py
@@ -45,7 +45,7 @@ class TestExpiredEmailConfirmationCodeJanitorService:
         user = models.User.objects.get_one(
             filters={"uuid": auth_test1_user.uuid}
         )
-        user.reset_confirmation_code()
+        user.create_confirmation_code()
         user.confirmation_code_made_at = code_made_at
         user.save()
 
@@ -61,7 +61,7 @@ class TestExpiredEmailConfirmationCodeJanitorService:
         user = models.User.objects.get_one(
             filters={"uuid": auth_test1_user.uuid}
         )
-        user.reset_confirmation_code()
+        user.create_confirmation_code()
         # Check the code is valid right now:
         assert user.check_confirmation_code(user.confirmation_code)
 

--- a/genesis_core/user_api/iam/dm/models.py
+++ b/genesis_core/user_api/iam/dm/models.py
@@ -316,7 +316,7 @@ class User(
         ctx = contexts.get_context()
         event_client = ctx.context_storage.get(iam_c.STORAGE_KEY_EVENTS_CLIENT)
 
-        self.reset_confirmation_code()
+        self.create_confirmation_code()
 
         registration_event_payload = event_payloads.ResetPasswordEventPayload(
             site_endpoint=app_endpoint,
@@ -332,7 +332,7 @@ class User(
         )
 
     def resend_confirmation_event(self, app_endpoint="http://localhost/"):
-        self.reset_confirmation_code()
+        self.create_confirmation_code()
         self.save()
         self.send_registration_event(app_endpoint=app_endpoint)
 
@@ -348,8 +348,11 @@ class User(
             return self.confirm_email()
         raise iam_exceptions.CanNotConfirmUser(code=code)
 
-    def reset_confirmation_code(self):
-        self.confirmation_code = sys_uuid.uuid4()
+    def create_confirmation_code(self):
+        # Janitor service will call .clear_confirmation_code()
+        # to set confirmation_code and confirmation_code_made_at to nulls,
+        # hourly, for all expired codes.
+        self.confirmation_code = self.confirmation_code or sys_uuid.uuid4()
         self.confirmation_code_made_at = datetime.datetime.now(
             datetime.timezone.utc
         )


### PR DESCRIPTION
Use-case:
- user registers, gets a "welcome" email with an email confirmation link (with a code)
- user forgets their password right away (ah, dummy), and requests password reset - another email is sent to him with another link (with a code).

2nd action now makes 1st email's link invalid, which results in a weird UX.
This is a simple fix to solve this problem.

Old codes are wiped by the janitor daemon hourly regardless.