### PR TITLE
security(iam): prevent user enumeration in get_token

### DIFF
--- a/genesis_core/tests/functional/restapi/iam/test_users.py
+++ b/genesis_core/tests/functional/restapi/iam/test_users.py
@@ -475,7 +475,7 @@ class TestUsers(base.BaseIamResourceTest):
             ("phone", None, pytest.raises(bazooka_exc.BaseHTTPException)),
             ("username", "wrong", pytest.raises(bazooka_exc.BadRequestError)),
             ("username", "", pytest.raises(bazooka_exc.BadRequestError)),
-            ("null", None, pytest.raises(bazooka_exc.NotFoundError)),
+            ("null", None, pytest.raises(bazooka_exc.BadRequestError)),
         ],
     )
     def test_auth_with_login(

--- a/genesis_core/user_api/iam/constants.py
+++ b/genesis_core/user_api/iam/constants.py
@@ -58,6 +58,11 @@ USER_CONFIRMATION_CODE_TTL = timedelta(hours=1)
 PARAM_SCOPE_DEFAULT = ""
 
 
+# Used for dummy PBKDF2 hash computation when user is missing to reduce timing
+# differences and prevent username enumeration in password-grant flow.
+DUMMY_PBKDF2_SALT = "AAAAAAAAAAAAAAAAAAAAAAAA"
+
+
 # Algorithms
 ALGORITHM_HS256 = "HS256"
 


### PR DESCRIPTION
- Return invalid-credentials error for missing users (same as wrong password)
- Run dummy PBKDF2 for missing users to reduce timing differences
- Add functional test ensuring same error for no-user and wrong-password