### PR TITLE
Manifest f-string: remove closing double quotes even with trailing spaces

### DIFF
--- a/genesis_core/elements/dm/models.py
+++ b/genesis_core/elements/dm/models.py
@@ -663,7 +663,7 @@ class Resource(
             return re.sub(
                 self.__inline_vars_regex__,
                 partial(self._fstring_replacement_callback, engine=engine),
-                value[2:-1],
+                value[2 : value.rfind('"')],
             )
 
         return value


### PR DESCRIPTION
This example will give us some newlines and spaces after last `"`:
```yaml
  $core.config.configs:
    genesis_jitsi_config:
      body:
        kind: text
        content: |
          f"
          JITSI_HOST=meet.{$core.compute.nodes.$genesis_jitsi:name}
          JITSI_BRANDING=false
          "

  $core.network.lb:
    something: true
```

Return string will be (see last double quote):
```
"\nJITSI_HOST=meet.SOME_DOMAIN\nJITSI_BRANDING=false\n\""
```

Fix it by search for last double quotes position.