### PR TITLE
Add Keycloak user source support and user_source migration

### DIFF
--- a/genesis_core/user_api/iam/api/controllers.py
+++ b/genesis_core/user_api/iam/api/controllers.py
@@ -128,6 +128,7 @@ class UserController(
         process_filters=True,
         hidden_fields=resources.HiddenFieldMap(
             get=[
+                "user_source",
                 "salt",
                 "secret_hash",
                 "secret",
@@ -143,6 +144,7 @@ class UserController(
                 "confirmation_code_made_at",
             ],
             update=[
+                "user_source",
                 "salt",
                 "secret_hash",
                 "secret",
@@ -151,6 +153,7 @@ class UserController(
                 "confirmation_code_made_at",
             ],
             filter=[
+                "user_source",
                 "salt",
                 "secret_hash",
                 "secret",
@@ -159,6 +162,7 @@ class UserController(
                 "confirmation_code_made_at",
             ],
             action_post=[
+                "user_source",
                 "salt",
                 "secret_hash",
                 "secret",

--- a/genesis_core/user_api/iam/clients/keycloak.py
+++ b/genesis_core/user_api/iam/clients/keycloak.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import urllib.parse
+
+import bazooka
+
+
+class KeycloakClient:
+
+    def __init__(self, endpoint, timeout=5):
+        super().__init__()
+        self._endpoint = endpoint
+        self._client = bazooka.Client(default_timeout=timeout)
+
+    def check_password(self, realm, client_id, client_secret, login, password):
+        endpoint = self._endpoint.rstrip("/") + "/"
+        token_endpoint = urllib.parse.urljoin(
+            endpoint,
+            (f"realms/{realm}/protocol/openid-connect/token"),
+        )
+
+        response = self._client.post(
+            token_endpoint,
+            data={
+                "grant_type": "password",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "username": login,
+                "password": password,
+            },
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+        )
+
+        return response.status_code == 200

--- a/migrations/0043-add-user-source-4f5e1f.py
+++ b/migrations/0043-add-user-source-4f5e1f.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import migrations
+
+
+class MigrationStep(migrations.AbstractMigrationStep):
+
+    def __init__(self):
+        self._depends = [
+            "0042-compute-ua-integration-4bd866.py",
+        ]
+
+    @property
+    def migration_id(self):
+        return "4f5e1f94-0f37-4c24-8c37-522ce3c6c5c6"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        expressions = [
+            """
+                ALTER TABLE "iam_users"
+                ADD COLUMN IF NOT EXISTS "user_source" JSONB
+                    NOT NULL DEFAULT '{"kind": "IAM"}'::jsonb;
+            """,
+        ]
+
+        for expression in expressions:
+            session.execute(expression)
+
+    def downgrade(self, session):
+        expressions = [
+            """
+                ALTER TABLE "iam_users"
+                DROP COLUMN IF EXISTS "user_source";
+            """,
+        ]
+
+        for expression in expressions:
+            session.execute(expression)
+
+
+migration_step = MigrationStep()

--- a/migrations/MANUAL-computeV2-e26427.py
+++ b/migrations/MANUAL-computeV2-e26427.py
@@ -29,7 +29,7 @@ class MigrationStep(migrations.AbstractMigrationStep):
 
     @property
     def is_manual(self):
-        return False
+        return True
 
     def upgrade(self, session):
         expressions = [


### PR DESCRIPTION
* **Keycloak Integration**: A new Keycloak client has been added to facilitate external user authentication using Keycloak's password grant flow.
* **Flexible User Source Mechanism**: The `User` model now includes a `user_source` property, allowing users to be associated with different authentication backends, such as the internal IAM or an external Keycloak instance. This introduces `AbstractUserSource`, `IamUserSource`, and `KeycloakUserSource` models.
* **Database Migration for User Source**: A new database migration script has been added to introduce a `user_source` JSONB column to the `iam_users` table, defaulting to the internal IAM kind for existing users.
* **Migration Status Update**: An existing migration script (`MANUAL-computeV2-e26427.py`) has been updated to be explicitly marked as a manual migration.