### PR TITLE
Parallelize tests via xdist

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,13 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_USER: genesis_core
           POSTGRES_PASSWORD: genesis_core
+          POSTGRES_INITDB_ARGS: "-c max_connections=100"
         # Set health checks to wait until postgres has started
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432

--- a/genesis_core/tests/functional/conftest.py
+++ b/genesis_core/tests/functional/conftest.py
@@ -29,6 +29,7 @@ from gcl_sdk.events import clients as sdk_clients
 from gcl_sdk.infra.dm import models as sdk_infra_models
 from gcl_sdk.agents.universal.dm import models as sdk_ua_models
 from restalchemy.dm import filters as dm_filters
+from restalchemy.tests.functional.conftest import setup_db_for_worker
 
 from genesis_core.common import constants as c
 from genesis_core.common.dm import targets as ct

--- a/genesis_core/tests/functional/service/dns/conftest.py
+++ b/genesis_core/tests/functional/service/dns/conftest.py
@@ -44,7 +44,7 @@ def find_free_port():
 
 @pytest.fixture()
 def pdns_server(user_api, tmp_path_factory: pytest.TempPathFactory):
-    result = urlparse(ra_c.DATABASE_URI)
+    result = urlparse(ra_c.get_database_uri())
     if result.scheme != "postgresql":
         pytest.skip("Only PostgreSQL is supported for PowerDNS tests")
     if not os.path.exists(PDNS_BIN):

--- a/genesis_core/tests/functional/service/dns/test_pdns.py
+++ b/genesis_core/tests/functional/service/dns/test_pdns.py
@@ -60,8 +60,7 @@ class TestDnsApi:
         assert self._cmp_shallow(domain, output)
         yield output
 
-    # DNS
-
+    @pytest.mark.xdist_group(name="pdns")
     def test_domains_list(
         self,
         user_api_client: iam_clients.GenesisCoreTestRESTClient,
@@ -75,6 +74,7 @@ class TestDnsApi:
         assert response.status_code == 200
         assert len(response.json()) == 0
 
+    @pytest.mark.xdist_group(name="pdns")
     def test_domains_add(
         self,
         user_api_client: iam_clients.GenesisCoreTestRESTClient,
@@ -126,6 +126,7 @@ class TestDnsApi:
         assert response.status_code == 200
         assert len(response.json()) == 0
 
+    @pytest.mark.xdist_group(name="pdns")
     def test_a_record(
         self,
         user_api_client: iam_clients.GenesisCoreTestRESTClient,
@@ -174,6 +175,7 @@ class TestDnsApi:
 
         assert response.status_code == 204
 
+    @pytest.mark.xdist_group(name="pdns")
     def test_txt_record(
         self,
         user_api_client: iam_clients.GenesisCoreTestRESTClient,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pbr>=1.10.0,<=5.8.1  # Apache-2.0
 oslo.config>=3.22.2,<10.0.0  # Apache-2.0
 bjoern>=3.2.2  # BSD License (BSD-3-Clause)
 gcl_looper>=1.0.1,<=2.0.0  # Apache-2.0
-restalchemy>=14.4.0,<15.0.0  # Apache-2.0
+restalchemy>=14.7.0,<15.0.0  # Apache-2.0
 libvirt-python>=11.0.0,<12.0.0  # GNU Lesser General Public License v2 or later (LGPLv2+)
 Authlib>=1.3.2,<2.0.0  # BSD License (BSD-3-Clause)
 bazooka>=1.3.0,<2.0.0  # Apache-2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,5 @@ flake8>=6.1.0  # MIT License (MIT)
 mock>=3.0.5,<4.0.0  # BSD
 pytest>=8.0.0,<9.0.0  # MIT License (MIT)
 pytest-timer>=1.0.0,<2.0.0  # MIT License (MIT)
+pytest-xdist[psutil]>=3.6.1,<4.0.0  # MIT License (MIT)
 dnspython>=2.6.0,<3.0.0  # ISC License

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv =
   functional: TEST_PATH={env:PACKAGE_NAME}/tests/functional
   functional: DATABASE_URI={env:DATABASE_URI:postgresql://genesis_core:genesis_core@127.0.0.1:5432/genesis_core}
 commands =
-  coverage run -p -m pytest {posargs} --timer-top-n=10 {env:TEST_PATH}
+  coverage run -p -m pytest {posargs} --timer-top-n=10 -n 10 {env:TEST_PATH}
 
 
 [testenv:begin]


### PR DESCRIPTION
- before: 17m 4s  https://github.com/infraguys/genesis_core/actions/runs/20594003892/job/59144694563
- with this PR: 7m 15s https://github.com/infraguys/genesis_core/actions/runs/20667660932/job/59343052740?pr=213

Looks like we use all 4 cores of runner's VM now. We may parallelize further via distributing different groups of tests on different runners, but it's a different complexity.

On local machine with 8c/16t I've got `9m 12s` vs `1m 11s`  (`1m 0s` if use 20 workers, but it's not optimal)