### PR TITLE
Hotfix: Use correct disk spec for new LBs

### DIFF
--- a/genesis_core/network/lb/builders/iaas.py
+++ b/genesis_core/network/lb/builders/iaas.py
@@ -57,7 +57,7 @@ class LBBuilder(builder.CoreInfraBuilder):
             replicas=instance.type.nodes_number,
             project_id=self._project_id,
             status=sdk_c.NodeStatus.NEW.value,
-            disk_spec=sdk_models.SetDisksSpec(
+            disk_spec=sdk_models.SetRootDiskSpec(
                 size=instance.type.disk_size,
                 image=CONF.gservice.lb_image,
             ),


### PR DESCRIPTION
The incorrect disk spec doesn't allow to create new LBs for installations.