### PR TITLE
Make `nonce` as an optional parameters for specific IDP

### DIFF
--- a/genesis_core/user_api/iam/api/controllers.py
+++ b/genesis_core/user_api/iam/api/controllers.py
@@ -613,16 +613,16 @@ class IdpController(
         redirect_uri,
         state,
         response_type,
-        nonce,
         scope,
+        nonce=models.Idp.NONCE_DEFAULT,
     ):
         redirect_uri = resource.authorize(
             client_id=client_id,
             redirect_uri=redirect_uri,
             state=state,
             response_type=response_type,
-            nonce=nonce,
             scope=scope,
+            nonce=nonce,
         )
 
         return None, 307, [("Location", redirect_uri)]

--- a/genesis_core/user_api/iam/exceptions.py
+++ b/genesis_core/user_api/iam/exceptions.py
@@ -224,3 +224,10 @@ class InvalidRedirectUri(
     iam_exc.InvalidGrantTypeError,
 ):
     __template__ = "Invalid or unregistered redirect_uri: {redirect_uri}"
+
+
+class InvalidNonce(
+    exceptions.CommonValueErrorException,
+    iam_exc.InvalidGrantTypeError,
+):
+    __template__ = "Invalid or missing nonce: '{nonce}'"

--- a/migrations/0048-iam-nonce-optional-c6e9f6.py
+++ b/migrations/0048-iam-nonce-optional-c6e9f6.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import migrations
+
+
+class MigrationStep(migrations.AbstractMigrationStep):
+
+    def __init__(self):
+        self._depends = [
+            "0047-sdk-1-3-0-migration-33fdc9.py",
+        ]
+
+    @property
+    def migration_id(self):
+        return "c6e9f66a-086c-4e09-bcbd-80a2a4a6db14"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        expressions = [
+            """
+                ALTER TABLE "iam_idp"
+                    ADD COLUMN IF NOT EXISTS "nonce_required" BOOLEAN
+                    NOT NULL DEFAULT TRUE;
+            """,
+        ]
+
+        for expression in expressions:
+            session.execute(expression)
+
+    def downgrade(self, session):
+        expressions = [
+            """
+                ALTER TABLE "iam_idp"
+                    DROP COLUMN IF EXISTS "nonce_required";
+            """,
+        ]
+
+        for expression in expressions:
+            session.execute(expression)
+
+
+migration_step = MigrationStep()


### PR DESCRIPTION
Some clients doesn't support `nonce` in auth procedure. So make it's possible to not specify `nonce` for such clients.