### PR TITLE
IAM IDP: support multiple callback URI formats

### DIFF
--- a/genesis_core/tests/functional/restapi/iam/test_idp.py
+++ b/genesis_core/tests/functional/restapi/iam/test_idp.py
@@ -38,9 +38,17 @@ class TestIdp(base.BaseIamResourceTest):
         return {
             "name": "test-idp",
             "description": "test-idp-desc",
-            "callback_uri": "http://example.test/callback",
+            "callback": {
+                "kind": "callback_uri",
+                "callback": "http://example.test/callback",
+            },
             "iam_client": self._iam_client_uri(iam_client_uuid),
         }
+
+    def _build_create_payload_with_callback(self, iam_client_uuid: str, callback: dict):
+        payload = self._build_create_payload(iam_client_uuid)
+        payload["callback"] = callback
+        return payload
 
     def _create_idp(self, client, iam_client_uuid: str):
         url = self._collection_url(client)
@@ -82,6 +90,68 @@ class TestIdp(base.BaseIamResourceTest):
         idp = self._create_idp(client, iam_client_uuid=auth_test1_user.client_uuid)
 
         assert idp["name"] == "test-idp"
+
+    def test_create_idp_with_callback_uri_list_success(
+        self, user_api_client, auth_test1_user
+    ):
+        client = user_api_client(
+            auth_test1_user,
+            permissions=[
+                iam_c.PERMISSION_IDP_CREATE,
+            ],
+        )
+        url = self._collection_url(client)
+
+        response = client.post(
+            url,
+            json=self._build_create_payload_with_callback(
+                iam_client_uuid=auth_test1_user.client_uuid,
+                callback={
+                    "kind": "callback_uri_list",
+                    "callbacks": [
+                        "http://example.test/callback",
+                        "http://example.test/callback-2",
+                    ],
+                },
+            ),
+        )
+
+        assert response.status_code == 201
+        idp = response.json()
+        assert idp["callback"]["kind"] == "callback_uri_list"
+        assert idp["callback"]["callbacks"] == [
+            "http://example.test/callback",
+            "http://example.test/callback-2",
+        ]
+
+    def test_create_idp_with_callback_regexp_success(
+        self, user_api_client, auth_test1_user
+    ):
+        client = user_api_client(
+            auth_test1_user,
+            permissions=[
+                iam_c.PERMISSION_IDP_CREATE,
+            ],
+        )
+        url = self._collection_url(client)
+
+        response = client.post(
+            url,
+            json=self._build_create_payload_with_callback(
+                iam_client_uuid=auth_test1_user.client_uuid,
+                callback={
+                    "kind": "callback_regexp",
+                    "pattern": r"https://example\.test/callback(/.*)?",
+                },
+            ),
+        )
+
+        assert response.status_code == 201
+        idp = response.json()
+        assert idp["callback"]["kind"] == "callback_regexp"
+        assert idp["callback"]["pattern"] == (
+            r"https://example\.test/callback(/.*)?"
+        )
 
     def test_list_idp_no_permission_fails(self, user_api_client, auth_test1_user):
         client = user_api_client(auth_test1_user)

--- a/genesis_core/user_api/iam/dm/models.py
+++ b/genesis_core/user_api/iam/dm/models.py
@@ -17,6 +17,7 @@
 import base64
 import datetime
 import enum
+import re
 import hashlib
 import secrets
 import typing as tp
@@ -166,6 +167,48 @@ class IdpResponseType(str, enum.Enum):
     @classmethod
     def list_response_types(cls):
         return [cls.CODE.value]
+
+
+class IdpCallbackBase(ra_types_dynamic.AbstractKindModel, models.SimpleViewMixin):
+    def check(self, redirect_uri: str) -> bool:
+        raise NotImplementedError()
+
+
+class IdpCallbackUriKind(IdpCallbackBase):
+    KIND = "callback_uri"
+
+    callback = properties.property(
+        ra_types.String(max_length=256),
+        required=True,
+    )
+
+    def check(self, redirect_uri: str) -> bool:
+        return self.callback == redirect_uri
+
+
+class IdpCallbackUriListKind(IdpCallbackBase):
+    KIND = "callback_uri_list"
+
+    callbacks = properties.property(
+        ra_types.TypedList(ra_types.String(max_length=256)),
+        required=True,
+        default=list,
+    )
+
+    def check(self, redirect_uri: str) -> bool:
+        return redirect_uri in self.callbacks
+
+
+class IdpCallbackRegexpKind(IdpCallbackBase):
+    KIND = "callback_regexp"
+
+    pattern = properties.property(
+        ra_types.String(max_length=256),
+        required=True,
+    )
+
+    def check(self, redirect_uri: str) -> bool:
+        return re.fullmatch(self.pattern, redirect_uri) is not None
 
 
 class AbstractUserSource(ra_types_dynamic.AbstractKindModel):
@@ -1091,7 +1134,7 @@ class IamClient(
         for auth_info in IdpAuthorizationInfo.objects.get_all(
             filters={"code": ra_filters.EQ(code)}
         ):
-            if auth_info.idp.callback_uri == redirect_uri:
+            if auth_info.redirect_uri == redirect_uri:
                 auth_info.delete()
                 return auth_info.token
 
@@ -1495,8 +1538,12 @@ class Idp(
         ra_types.String(max_length=64),
         default="openid",
     )
-    callback_uri = properties.property(
-        ra_types.String(max_length=256),
+    callback = properties.property(
+        KindModelSelectorType(
+            ra_types_dynamic.KindModelType(IdpCallbackUriKind),
+            ra_types_dynamic.KindModelType(IdpCallbackUriListKind),
+            ra_types_dynamic.KindModelType(IdpCallbackRegexpKind),
+        ),
         required=True,
     )
     nonce_required = properties.property(
@@ -1560,7 +1607,7 @@ class Idp(
     ):
         if self.client_id != client_id:
             raise iam_exceptions.InvalidClientId(client_id=client_id)
-        if self.callback_uri != redirect_uri:
+        if not self.callback.check(redirect_uri):
             raise iam_exceptions.InvalidRedirectUri(redirect_uri=redirect_uri)
         if self.nonce_required and not nonce:
             raise iam_exceptions.InvalidNonce(nonce=nonce)
@@ -1574,6 +1621,7 @@ class Idp(
             response_type=response_type,
             nonce=nonce,
             scope=scope,
+            redirect_uri=redirect_uri,
         )
 
         auth_info.insert()
@@ -1586,7 +1634,11 @@ class Idp(
         )
 
     def construct_callback_uri(self, auth_info):
-        return self.callback_uri + f"?code={auth_info.code}&state={auth_info.state}"
+        if not auth_info.redirect_uri:
+            raise iam_exceptions.InvalidRedirectUri(redirect_uri="")
+        return (
+            auth_info.redirect_uri + f"?code={auth_info.code}&state={auth_info.state}"
+        )
 
 
 class IdpAuthorizationInfo(
@@ -1611,6 +1663,11 @@ class IdpAuthorizationInfo(
     nonce = properties.property(
         ra_types.String(max_length=256),
         required=True,
+    )
+    redirect_uri = properties.property(
+        ra_types.String(max_length=256),
+        required=True,
+        default="",
     )
     scope = properties.property(
         ra_types.String(max_length=256),

--- a/migrations/0054-iam-idp-callback-kind-3a6c1b.py
+++ b/migrations/0054-iam-idp-callback-kind-3a6c1b.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import migrations
+
+
+class MigrationStep(migrations.AbstractMigrationStep):
+    def __init__(self):
+        self._depends = [
+            "0053-lb-node-secret-set-permissions-11c9a8.py",
+        ]
+
+    @property
+    def migration_id(self):
+        return "3a6c1b7a-20a0-4d3b-8896-d183f5eb2e6b"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        expressions = [
+            """
+                ALTER TABLE "iam_idp"
+                ADD COLUMN IF NOT EXISTS "callback" JSONB
+                    NOT NULL DEFAULT '{"kind": "callback_uri", "callback": ""}'::jsonb;
+            """,
+            """
+                UPDATE "iam_idp"
+                SET "callback" = jsonb_build_object(
+                    'kind', 'callback_uri',
+                    'callback', COALESCE("callback_uri", '')
+                );
+            """,
+            """
+                ALTER TABLE "iam_idp"
+                DROP COLUMN IF EXISTS "callback_uri";
+            """,
+            """
+                DELETE FROM "iam_idp_authorization_info";
+            """,
+            """
+                ALTER TABLE "iam_idp_authorization_info"
+                ADD COLUMN IF NOT EXISTS "redirect_uri" VARCHAR(256)
+                    NOT NULL DEFAULT '';
+            """,
+        ]
+
+        for expression in expressions:
+            session.execute(expression)
+
+    def downgrade(self, session):
+        expressions = [
+            """
+                ALTER TABLE "iam_idp"
+                ADD COLUMN IF NOT EXISTS "callback_uri" VARCHAR(256)
+                    NOT NULL DEFAULT '';
+            """,
+            """
+                UPDATE "iam_idp"
+                SET "callback_uri" = COALESCE("callback"->>'callback', '');
+            """,
+            """
+                ALTER TABLE "iam_idp"
+                DROP COLUMN IF EXISTS "callback";
+            """,
+            """
+                ALTER TABLE "iam_idp_authorization_info"
+                DROP COLUMN IF EXISTS "redirect_uri";
+            """,
+        ]
+
+        for expression in expressions:
+            session.execute(expression)
+
+
+migration_step = MigrationStep()


### PR DESCRIPTION
- Flexible Callback URI Handling: Introduced a new callback model that supports three formats for Identity Provider (IDP) callback URIs: a single URI, a list of URIs, and a regular expression pattern. This replaces the previous single string callback_uri.
- Enhanced Redirect URI Validation: The Idp model's authorization logic was updated to use the new flexible callback validation mechanism, allowing for more sophisticated matching of redirect URIs.
- Persistent Redirect URI Storage: The redirect_uri is now stored within the IdpAuthorizationInfo during the authorization flow. This ensures that the exact redirect URI used for authorization is available for validation during the token exchange phase, improving security.
- Database Schema Migration: A new database migration was added to transition the iam_idp table from a simple callback_uri string column to a callback JSONB column, and to add a redirect_uri column to the iam_idp_authorization_info table.