### PR TITLE
UA configuration don't use default password for drivers

### DIFF
--- a/etc/genesis_universal_agent/genesis_universal_agent.conf.j2
+++ b/etc/genesis_universal_agent/genesis_universal_agent.conf.j2
@@ -30,12 +30,12 @@ capabilities =
 
 [CoreDNSCertificateCapabilityDriver]
 username = admin
-password = admin
+password = {{ admin_password }}
 user_api_base_url = http://localhost:11010/v1
 
 
 [RestCoreCapabilityDriver]
 username = admin
-password = admin
+password = {{ admin_password }}
 user_api_base_url = http://localhost:11010
 em_core_iam_users = /v1/iam/users/

--- a/genesis/images/bootstrap.sh
+++ b/genesis/images/bootstrap.sh
@@ -350,4 +350,4 @@ sudo sysctl -p
 sudo iptables -t nat -A POSTROUTING -o enp1s0 -j MASQUERADE
 
 # Save iptables rules
-sudo sh -c "iptables-save > /etc/iptables/rules.v4"
+sudo netfilter-persistent save

--- a/genesis_core/cmd/bootstrap_templates.py
+++ b/genesis_core/cmd/bootstrap_templates.py
@@ -155,6 +155,7 @@ def _build_template_context(spec: dict[str, tp.Any]) -> dict[str, str]:
         "boot_ip_with_mask": f"{boot_ip}/{boot_network.prefixlen}",
         "global_salt": secret_utils.generate_salt(),
         "hs256_jwks_encryption_key": secret_utils.generate_a256gcm_key(),
+        "admin_password": spec["admin_password"],
     }
 
 


### PR DESCRIPTION
For CoreDNSCertificateCapabilityDriver and RestCoreCapabilityDriver use generated password instead of default one.

Closes (#266 )