### PR TITLE
Add IAM audit logging for user actions and authentication events

### DIFF
--- a/genesis_core/common/contexts.py
+++ b/genesis_core/common/contexts.py
@@ -16,8 +16,11 @@
 
 import typing as tp
 
+import netaddr
 from gcl_iam import contexts as iam_contexts
 from restalchemy.api import packers
+
+from genesis_core.user_api.iam.dm import models
 
 _RAW_PAYLOAD_MISSING = object()
 
@@ -26,6 +29,28 @@ class GenesisCoreAuthContext(iam_contexts.GenesisCoreAuthContext):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._raw_payload_cache = _RAW_PAYLOAD_MISSING
+
+    def get_user_ip(self) -> tp.Optional[netaddr.IPAddress]:
+        request = self.request
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            return netaddr.IPAddress(forwarded_for.split(",")[0].strip())
+        real_ip = request.headers.get("X-Real-IP")
+        if real_ip:
+            return netaddr.IPAddress(real_ip.strip())
+        remote_addr = getattr(request, "remote_addr", None) or getattr(
+            request, "client_addr", None
+        )
+        if remote_addr:
+            return netaddr.IPAddress(str(remote_addr))
+        environ = getattr(request, "environ", None)
+        if environ:
+            remote_env = environ.get("REMOTE_ADDR")
+            return netaddr.IPAddress(remote_env) if remote_env else None
+        return None
+
+    def me(self):
+        return models.User.me()
 
     def get_raw_payload(self) -> tp.Any:
         if self._raw_payload_cache is not _RAW_PAYLOAD_MISSING:

--- a/genesis_core/user_api/iam/api/controllers.py
+++ b/genesis_core/user_api/iam/api/controllers.py
@@ -15,6 +15,7 @@
 #    under the License.
 
 import errno
+import logging
 from os import path as os_path
 import mimetypes
 import re
@@ -43,6 +44,9 @@ from genesis_core.user_api.iam.clients import idp
 from genesis_core.user_api.iam.dm import models
 from genesis_core.user_api.iam import constants as c
 from genesis_core.user_api.iam import exceptions as iam_e
+
+
+LOG = logging.getLogger(__name__)
 
 
 class EnforceMixin:
@@ -161,6 +165,13 @@ class UserController(
         user = super().create(**kwargs)
         app_endpoint = _get_app_endpoint(req=self._req)
         user.resend_confirmation_event(app_endpoint=app_endpoint)
+        ctx = self.get_context()
+        LOG.info(
+            "IAM AUDIT: user created name=%s uuid=%s ip=%s",
+            user.name,
+            user.uuid,
+            ctx.get_user_ip(),
+        )
         return user
 
     def filter(self, filters, **kwargs):
@@ -457,6 +468,21 @@ class RoleBindingController(
     __policy_service_name__ = "iam"
     __policy_name__ = "role_binding"
 
+    def create(self, **kwargs):
+        role_binding = super().create(**kwargs)
+        user = role_binding.user
+        role = role_binding.role
+        ctx = self.get_context()
+        LOG.info(
+            "IAM AUDIT: role granted user=%s user_uuid=%s role=%s role_uuid=%s ip=%s",
+            user.name,
+            user.uuid,
+            role.name,
+            role.uuid,
+            ctx.get_user_ip(),
+        )
+        return role_binding
+
 
 class PermissionController(
     iam_controllers.PolicyBasedWithoutProjectController,
@@ -482,6 +508,48 @@ class PermissionBindingController(
 
     __policy_service_name__ = "iam"
     __policy_name__ = "permission_binding"
+
+    def create(self, **kwargs):
+        binding = super().create(**kwargs)
+        role = binding.role
+        permission = binding.permission
+        ctx = self.get_context()
+        actor = ctx.me()
+        LOG.info(
+            "IAM AUDIT: permission added actor=%s actor_uuid=%s role=%s role_uuid=%s permission=%s ip=%s",
+            actor.name,
+            actor.uuid,
+            role.name,
+            role.uuid,
+            permission.name,
+            ctx.get_user_ip(),
+        )
+        return binding
+
+    def delete(self, uuid):
+        binding = None
+        for item in models.PermissionBinding.objects.get_all(
+            filters={"uuid": ra_filters.EQ(uuid)},
+            limit=1,
+        ):
+            binding = item
+            break
+        result = super().delete(uuid)
+        if binding:
+            role = binding.role
+            permission = binding.permission
+            ctx = self.get_context()
+            actor = ctx.me()
+            LOG.info(
+                "IAM AUDIT: permission removed actor=%s actor_uuid=%s role=%s role_uuid=%s permission=%s ip=%s",
+                actor.name,
+                actor.uuid,
+                role.name,
+                role.uuid,
+                permission.name,
+                ctx.get_user_ip(),
+            )
+        return result
 
 
 class WellKnownController(
@@ -687,6 +755,7 @@ class ClientsController(controllers.BaseResourceControllerPaginated, EnforceMixi
                 resource.get_token_by_password_login,
             ),
         }
+        ctx = self.get_context()
         if grant_type in grant_type_map:
             client_id = kwargs.get(
                 c.PARAM_CLIENT_ID,
@@ -716,17 +785,63 @@ class ClientsController(controllers.BaseResourceControllerPaginated, EnforceMixi
             if not payload[login_attr]:
                 raise ra_e.ValidationErrorException()
 
-            token = token_getter(**payload)
+            try:
+                token = token_getter(**payload)
+            except Exception:
+                LOG.info(
+                    "IAM AUDIT: login failed grant_type=%s login=%s ip=%s",
+                    grant_type,
+                    kwargs.get(login_attr),
+                    ctx.get_user_ip(),
+                )
+                raise
+            LOG.info(
+                "IAM AUDIT: login success user=%s uuid=%s wildcard=%s ip=%s",
+                token.user.name,
+                token.user.uuid,
+                token.has_permission(c.PERMISSION_WILDCARD_NAME),
+                ctx.get_user_ip(),
+            )
 
         elif grant_type == c.GRANT_TYPE_REFRESH_TOKEN:
-            token = resource.get_token_by_refresh_token(
-                refresh_token=kwargs.get("refresh_token"),
-                scope=kwargs.get(c.PARAM_SCOPE, None),
+            try:
+                token = resource.get_token_by_refresh_token(
+                    refresh_token=kwargs.get("refresh_token"),
+                    scope=kwargs.get(c.PARAM_SCOPE, None),
+                )
+            except Exception:
+                LOG.info(
+                    "IAM AUDIT: login failed grant_type=%s ip=%s",
+                    grant_type,
+                    ctx.get_user_ip(),
+                )
+                raise
+            LOG.info(
+                "IAM AUDIT: login success user=%s uuid=%s wildcard=%s ip=%s",
+                token.user.name,
+                token.user.uuid,
+                token.has_permission(c.PERMISSION_WILDCARD_NAME),
+                ctx.get_user_ip(),
             )
         elif grant_type == c.GRANT_TYPE_AUTHORIZATION_CODE:
-            token = resource.get_token_by_authorization_code(
-                code=kwargs.get(c.PARAM_CODE),
-                redirect_uri=kwargs.get(c.PARAM_REDIRECT_URI),
+            try:
+                token = resource.get_token_by_authorization_code(
+                    code=kwargs.get(c.PARAM_CODE),
+                    redirect_uri=kwargs.get(c.PARAM_REDIRECT_URI),
+                )
+            except Exception:
+                LOG.info(
+                    "IAM AUDIT: login failed grant_type=%s ip=%s",
+                    grant_type,
+                    ctx.get_user_ip(),
+                )
+                raise
+            LOG.info(
+                "IAM AUDIT: login success user=%s uuid=%s wildcard=%s ip=%s",
+                token.user.name,
+                token.user.uuid,
+                token.has_permission(c.PERMISSION_WILDCARD_NAME),
+                ctx.get_user_ip(),
             )
         else:
             raise iam_e.InvalidGrantType(grant_type=grant_type)

--- a/genesis_core/user_api/iam/constants.py
+++ b/genesis_core/user_api/iam/constants.py
@@ -243,3 +243,6 @@ PERMISSION_IDP_UPDATE = rules.Rule.from_raw(
 PERMISSION_IDP_DELETE = rules.Rule.from_raw(
     "iam.idp.delete",
 )
+
+
+PERMISSION_WILDCARD_NAME = "*.*.*"

--- a/genesis_core/user_api/iam/dm/models.py
+++ b/genesis_core/user_api/iam/dm/models.py
@@ -1426,6 +1426,22 @@ class Token(
         self.scope = scope
         self.update()
 
+    def has_permission(self, name: str) -> bool:
+        for permission in Permission.objects.get_all(
+            filters={"name": ra_filters.EQ(name)},
+            limit=1,
+        ):
+            for _ in PermissionFastView.objects.get_all(
+                filters={
+                    "user": ra_filters.EQ(self.user),
+                    "project": ra_filters.Is(self.project),
+                    "permission": ra_filters.EQ(permission),
+                },
+                limit=1,
+            ):
+                return True
+        return False
+
     def get_response_body(self):
         now = datetime.datetime.now(datetime.timezone.utc)
         algorithm = self.iam_client.get_token_algorithm()


### PR DESCRIPTION
Track user creation, role grants, permission changes, and login attempts with IP addresses. Add get_user_ip() method to extract client IP from various request headers and me() method to get current user. Log both successful and failed authentication attempts across password, refresh token, and authorization code grant types.

Track whether authenticated users have wildcard permissions (*.*.*) in audit logs for password, refresh token, and authorization code grant types. Add has_permission() method to Token model to check user permissions via PermissionFastView.