### PR TITLE
iam: add reset_password and send_reset_password_code actions with permissions

### DIFF
--- a/genesis_core/tests/functional/restapi/iam/test_reset_password.py
+++ b/genesis_core/tests/functional/restapi/iam/test_reset_password.py
@@ -1,0 +1,334 @@
+#    Copyright 2025-2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import pytest
+from bazooka import exceptions as bazooka_exc
+from gcl_iam.tests.functional import clients as iam_clients
+
+from genesis_core.tests.functional.restapi.iam import base
+from genesis_core.user_api.iam import constants as iam_c
+from genesis_core.user_api.iam.dm import models as iam_models
+
+
+class TestUserResetPassword(base.BaseIamResourceTest):
+    """Tests for POST /v1/iam/users/<uuid>/actions/reset_password/invoke"""
+
+    @pytest.fixture()
+    def target_user(self, user_api_client, auth_user_admin):
+        """Create and confirm a regular user for reset_password tests."""
+        admin_client = user_api_client(
+            auth_user_admin,
+            permissions=[iam_c.PERMISSION_USER_CREATE],
+        )
+        password = "OldPassword1"
+        user = admin_client.create_user(
+            username="reset-pwd-target",
+            password=password,
+            email="reset-pwd-target@test.com",
+        )
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": user["uuid"]}
+        )
+        admin_client.confirm_email(
+            user_uuid=user_obj.uuid,
+            code=str(user_obj.confirmation_code),
+        )
+        return user, password
+
+    def _reset_password_url(self, client, user_uuid):
+        return client.build_resource_uri(
+            ["iam/users", user_uuid, "actions/reset_password/invoke"]
+        )
+
+    def test_reset_password_with_valid_code_success(
+        self, user_api_client, auth_user_admin, target_user
+    ):
+        """Reset password using valid confirmation code — no permission required."""
+        user, _ = target_user
+        admin_client = user_api_client(auth_user_admin)
+
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": user["uuid"]}
+        )
+        user_obj.create_confirmation_code()
+        code = str(user_obj.confirmation_code)
+
+        new_password = "NewPassword1"
+        result = admin_client.post(
+            self._reset_password_url(admin_client, user["uuid"]),
+            json={"new_password": new_password, "code": code},
+        ).json()
+
+        assert result["uuid"] == user["uuid"]
+
+    def test_reset_password_with_permission_no_code_success(
+        self, user_api_client, auth_user_admin, target_user
+    ):
+        """Reset password using iam.user.reset_password permission — no code required."""
+        user, _ = target_user
+        client = user_api_client(
+            auth_user_admin,
+            permissions=[iam_c.PERMISSION_USER_RESET_PASSWORD],
+        )
+
+        result = client.post(
+            self._reset_password_url(client, user["uuid"]),
+            json={"new_password": "NewPassword2"},
+        ).json()
+
+        assert result["uuid"] == user["uuid"]
+
+    def test_reset_password_no_code_no_permission_forbidden(
+        self, user_api_client, auth_test1_user, target_user
+    ):
+        """Without code and without permission — must return 403."""
+        user, _ = target_user
+        client = user_api_client(auth_test1_user)
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            client.post(
+                self._reset_password_url(client, user["uuid"]),
+                json={"new_password": "NewPassword3"},
+            )
+
+    def test_reset_password_new_password_works_for_login(
+        self,
+        user_api_client,
+        auth_user_admin,
+        target_user,
+        default_client_uuid,
+        default_client_id,
+        default_client_secret,
+    ):
+        """After successful reset, user can log in with new password."""
+        user, _ = target_user
+        admin_client = user_api_client(
+            auth_user_admin,
+            permissions=[iam_c.PERMISSION_USER_RESET_PASSWORD],
+        )
+        new_password = "AfterReset1"
+
+        admin_client.post(
+            self._reset_password_url(admin_client, user["uuid"]),
+            json={"new_password": new_password},
+        )
+
+        new_auth = iam_clients.GenesisCoreAuth(
+            username=user["username"],
+            password=new_password,
+            client_uuid=default_client_uuid,
+            client_id=default_client_id,
+            client_secret=default_client_secret,
+        )
+        new_client = user_api_client(new_auth)
+        me = new_client.me()
+
+        assert me["user"]["uuid"] == user["uuid"]
+
+    def test_reset_password_invalid_code_fails(
+        self, user_api_client, auth_user_admin, target_user
+    ):
+        """Invalid confirmation code must result in 403 (CanNotConfirmUser)."""
+        user, _ = target_user
+        admin_client = user_api_client(auth_user_admin)
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            admin_client.post(
+                self._reset_password_url(admin_client, user["uuid"]),
+                json={
+                    "new_password": "NewPassword4",
+                    "code": "00000000-0000-0000-0000-000000000000",
+                },
+            )
+
+    def test_reset_password_weak_password_fails(
+        self, user_api_client, auth_user_admin, target_user
+    ):
+        """Password that fails validation (too short) must return 400."""
+        user, _ = target_user
+        admin_client = user_api_client(
+            auth_user_admin,
+            permissions=[iam_c.PERMISSION_USER_RESET_PASSWORD],
+        )
+
+        with pytest.raises(bazooka_exc.BadRequestError):
+            admin_client.post(
+                self._reset_password_url(admin_client, user["uuid"]),
+                json={"new_password": "short"},
+            )
+
+
+class TestSendResetPasswordCode(base.BaseIamResourceTest):
+    """Tests for POST /v1/iam/clients/<uuid>/actions/send_reset_password_code/invoke"""
+
+    @pytest.fixture()
+    def target_user(self, user_api_client, auth_user_admin):
+        """Create and confirm a user for send_reset_password_code tests."""
+        admin_client = user_api_client(
+            auth_user_admin,
+            permissions=[iam_c.PERMISSION_USER_CREATE],
+        )
+        password = "SomePassword1"
+        user = admin_client.create_user(
+            username="send-reset-code-target",
+            password=password,
+            email="send-reset-code@test.com",
+        )
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": user["uuid"]}
+        )
+        admin_client.confirm_email(
+            user_uuid=user_obj.uuid,
+            code=str(user_obj.confirmation_code),
+        )
+        return user, password
+
+    def _send_reset_code_url(self, client, client_uuid):
+        return client.build_resource_uri(
+            [
+                "iam/clients",
+                client_uuid,
+                "actions/send_reset_password_code/invoke",
+            ]
+        )
+
+    def test_send_reset_password_code_with_permission_success(
+        self,
+        user_api_client,
+        auth_user_admin,
+        target_user,
+        default_client_uuid,
+    ):
+        """Admin with permission can send reset code."""
+        user, _ = target_user
+        client = user_api_client(
+            auth_user_admin,
+            permissions=[iam_c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE],
+        )
+
+        response = client.post(
+            self._send_reset_code_url(client, default_client_uuid),
+            json={"email": user["email"]},
+        )
+
+        assert response.status_code == 200
+
+    def test_send_reset_password_code_creates_confirmation_code(
+        self,
+        user_api_client,
+        auth_user_admin,
+        target_user,
+        default_client_uuid,
+    ):
+        """After sending, user gets a confirmation_code in DB."""
+        user, _ = target_user
+        client = user_api_client(
+            auth_user_admin,
+            permissions=[iam_c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE],
+        )
+
+        client.post(
+            self._send_reset_code_url(client, default_client_uuid),
+            json={"email": user["email"]},
+        )
+
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": user["uuid"]}
+        )
+        assert user_obj.confirmation_code is not None
+
+    def test_send_reset_password_code_without_permission_forbidden(
+        self,
+        user_api_client,
+        auth_test1_user,
+        target_user,
+        default_client_uuid,
+    ):
+        """User without permission gets 403."""
+        user, _ = target_user
+        client = user_api_client(auth_test1_user)
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            client.post(
+                self._send_reset_code_url(client, default_client_uuid),
+                json={"email": user["email"]},
+            )
+
+    def test_send_reset_password_code_nonexistent_email_no_error(
+        self,
+        user_api_client,
+        auth_user_admin,
+        default_client_uuid,
+    ):
+        """Non-existent email must not reveal user existence (no error)."""
+        client = user_api_client(
+            auth_user_admin,
+            permissions=[iam_c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE],
+        )
+
+        response = client.post(
+            self._send_reset_code_url(client, default_client_uuid),
+            json={"email": "nonexistent@example.com"},
+        )
+
+        assert response.status_code == 200
+
+    def test_send_reset_password_code_then_reset_password_flow(
+        self,
+        user_api_client,
+        auth_user_admin,
+        target_user,
+        default_client_uuid,
+        default_client_id,
+        default_client_secret,
+    ):
+        """Full flow: send code → reset password with code → login with new password."""
+        user, _ = target_user
+        admin_client = user_api_client(
+            auth_user_admin,
+            permissions=[iam_c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE],
+        )
+
+        admin_client.post(
+            self._send_reset_code_url(admin_client, default_client_uuid),
+            json={"email": user["email"]},
+        )
+
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": user["uuid"]}
+        )
+        code = str(user_obj.confirmation_code)
+        new_password = "FlowNewPass1"
+
+        reset_url = admin_client.build_resource_uri(
+            ["iam/users", user["uuid"], "actions/reset_password/invoke"]
+        )
+        admin_client.post(
+            reset_url,
+            json={"new_password": new_password, "code": code},
+        )
+
+        new_auth = iam_clients.GenesisCoreAuth(
+            username=user["username"],
+            password=new_password,
+            client_uuid=default_client_uuid,
+            client_id=default_client_id,
+            client_secret=default_client_secret,
+        )
+        new_client = user_api_client(new_auth)
+        me = new_client.me()
+
+        assert me["user"]["uuid"] == user["uuid"]

--- a/genesis_core/tests/functional/restapi/iam/test_reset_password.py
+++ b/genesis_core/tests/functional/restapi/iam/test_reset_password.py
@@ -286,6 +286,24 @@ class TestSendResetPasswordCode(base.BaseIamResourceTest):
 
         assert response.status_code == 200
 
+    def test_send_reset_password_code_missing_email_bad_request(
+        self,
+        user_api_client,
+        auth_user_admin,
+        default_client_uuid,
+    ):
+        """Missing email must return 400 instead of 500."""
+        client = user_api_client(
+            auth_user_admin,
+            permissions=[iam_c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE],
+        )
+
+        with pytest.raises(bazooka_exc.BadRequestError):
+            client.post(
+                self._send_reset_code_url(client, default_client_uuid),
+                json={},
+            )
+
     def test_send_reset_password_code_then_reset_password_flow(
         self,
         user_api_client,

--- a/genesis_core/tests/functional/restapi/iam/test_reset_password.py
+++ b/genesis_core/tests/functional/restapi/iam/test_reset_password.py
@@ -320,6 +320,12 @@ class TestSendResetPasswordCode(base.BaseIamResourceTest):
             permissions=[iam_c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE],
         )
 
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": user["uuid"]}
+        )
+        original_secret_hash = user_obj.secret_hash
+        assert user_obj.confirmation_code is None
+
         admin_client.post(
             self._send_reset_code_url(admin_client, default_client_uuid),
             json={"email": user["email"]},
@@ -328,6 +334,7 @@ class TestSendResetPasswordCode(base.BaseIamResourceTest):
         user_obj = iam_models.User.objects.get_one(
             filters={"uuid": user["uuid"]}
         )
+        assert user_obj.confirmation_code is not None
         code = str(user_obj.confirmation_code)
         new_password = "FlowNewPass1"
 
@@ -338,6 +345,12 @@ class TestSendResetPasswordCode(base.BaseIamResourceTest):
             reset_url,
             json={"new_password": new_password, "code": code},
         )
+
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": user["uuid"]}
+        )
+        assert user_obj.confirmation_code is None
+        assert user_obj.secret_hash != original_secret_hash
 
         new_auth = iam_clients.GenesisCoreAuth(
             username=user["username"],

--- a/genesis_core/tests/functional/restapi/iam/test_users.py
+++ b/genesis_core/tests/functional/restapi/iam/test_users.py
@@ -615,17 +615,31 @@ class TestUsers(base.BaseIamResourceTest):
         assert "access_token" in client._auth_cache
 
     def test_reset_password_success(
-        self, auth_test1_user, user_api, default_client_uuid
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_user,
+        default_client_uuid,
     ):
         user = iam_models.User.objects.get_one(filters={"uuid": auth_test1_user.uuid})
         # after confirm email (auth_test1_user) confirmation_code is None
         assert user.confirmation_code is None
 
-        url = urllib_parse.urljoin(
-            user_api.base_url,
-            f"iam/clients/{default_client_uuid}/actions/reset_password/invoke",
+        client = user_api_client(
+            auth_user_admin,
+            permissions=[
+                iam_c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE,
+            ],
         )
-        result = requests.post(url, json={"email": user.email})
+
+        send_url = client.build_resource_uri(
+            [
+                "iam/clients",
+                default_client_uuid,
+                "actions/send_reset_password_code/invoke",
+            ]
+        )
+        result = client.post(send_url, json={"email": user.email})
         assert result.status_code == 200
 
         user_updated = iam_models.User.objects.get_one(
@@ -635,12 +649,11 @@ class TestUsers(base.BaseIamResourceTest):
         assert user_updated.confirmation_code
 
         new_password = f"{auth_test1_user.password}_changed"
-        url = urllib_parse.urljoin(
-            user_api.base_url,
-            f"iam/users/{user.uuid}/actions/reset_password/invoke",
+        reset_url = client.build_resource_uri(
+            ["iam/users", user.uuid, "actions/reset_password/invoke"]
         )
-        result = requests.post(
-            url,
+        result = client.post(
+            reset_url,
             json={
                 "new_password": new_password,
                 "code": str(user_updated.confirmation_code),

--- a/genesis_core/tests/functional/restapi/iam/test_users.py
+++ b/genesis_core/tests/functional/restapi/iam/test_users.py
@@ -614,61 +614,6 @@ class TestUsers(base.BaseIamResourceTest):
         )  # tries to authorise on init
         assert "access_token" in client._auth_cache
 
-    def test_reset_password_success(
-        self,
-        user_api_client,
-        auth_user_admin,
-        auth_test1_user,
-        default_client_uuid,
-    ):
-        user = iam_models.User.objects.get_one(filters={"uuid": auth_test1_user.uuid})
-        # after confirm email (auth_test1_user) confirmation_code is None
-        assert user.confirmation_code is None
-
-        client = user_api_client(
-            auth_user_admin,
-            permissions=[
-                iam_c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE,
-            ],
-        )
-
-        send_url = client.build_resource_uri(
-            [
-                "iam/clients",
-                default_client_uuid,
-                "actions/send_reset_password_code/invoke",
-            ]
-        )
-        result = client.post(send_url, json={"email": user.email})
-        assert result.status_code == 200
-
-        user_updated = iam_models.User.objects.get_one(
-            filters={"uuid": auth_test1_user.uuid}
-        )
-        # after send reset password event confirmation_code present
-        assert user_updated.confirmation_code
-
-        new_password = f"{auth_test1_user.password}_changed"
-        reset_url = client.build_resource_uri(
-            ["iam/users", user.uuid, "actions/reset_password/invoke"]
-        )
-        result = client.post(
-            reset_url,
-            json={
-                "new_password": new_password,
-                "code": str(user_updated.confirmation_code),
-            },
-        )
-        assert result.status_code == 200
-
-        user_updated = iam_models.User.objects.get_one(
-            filters={"uuid": auth_test1_user.uuid}
-        )
-        # after reset password confirmation_code is None
-        assert user_updated.confirmation_code is None
-        # password changed
-        assert user_updated.secret_hash != user.secret_hash
-
     def test_create_service_user_success(self, user_api_client, auth_user_admin):
         """Test creating a service account"""
         client = user_api_client(

--- a/genesis_core/tests/functional/restapi/iam/test_users.py
+++ b/genesis_core/tests/functional/restapi/iam/test_users.py
@@ -15,10 +15,8 @@
 #    under the License.
 import contextlib
 import datetime
-from urllib import parse as urllib_parse
 
 import pytest
-import requests
 import jwt
 from bazooka import exceptions as bazooka_exc
 from gcl_iam.tests.functional import clients as iam_clients

--- a/genesis_core/user_api/iam/api/controllers.py
+++ b/genesis_core/user_api/iam/api/controllers.py
@@ -913,6 +913,8 @@ class ClientsController(controllers.BaseResourceControllerPaginated, EnforceMixi
                 rule=c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE,
             )
         email = email or self._req.params.get("email")
+        if not email:
+            raise ValidationException(description="Email is required")
         app_endpoint = _get_app_endpoint(req=self._req)
         resource.send_reset_password_event(email=email, app_endpoint=app_endpoint)
 

--- a/genesis_core/user_api/iam/api/controllers.py
+++ b/genesis_core/user_api/iam/api/controllers.py
@@ -288,17 +288,18 @@ class UserController(
     @actions.post
     def reset_password(self, resource, new_password=None, code=None):
         code = code or self._req.params.get("code")
-        if not code and not self.enforce(c.PERMISSION_USER_RESET_PASSWORD):
+        has_permission = self.enforce(c.PERMISSION_USER_RESET_PASSWORD)
+        if not code and not has_permission:
             raise iam_e.CanNotResetUserPassword(
                 uuid=resource.uuid,
                 rule=c.PERMISSION_USER_RESET_PASSWORD,
             )
         new_secret = new_password or self._req.params.get("new_password")
         self.validate(new_secret)
-        resource.reset_secret_by_code(
-            new_secret=new_secret,
-            code=code,
-        )
+        if code:
+            resource.reset_secret_by_code(new_secret=new_secret, code=code)
+        else:
+            resource.reset_secret(new_secret=new_secret)
         return resource
 
     @actions.get

--- a/genesis_core/user_api/iam/api/controllers.py
+++ b/genesis_core/user_api/iam/api/controllers.py
@@ -284,9 +284,15 @@ class UserController(
         resource.confirm_email_by_code(code)
         return resource
 
+    @oa_utils.extend_schema(**oa_specs.OA_SPEC_RESET_PASSWORD_USER)
     @actions.post
     def reset_password(self, resource, new_password=None, code=None):
         code = code or self._req.params.get("code")
+        if not code and not self.enforce(c.PERMISSION_USER_RESET_PASSWORD):
+            raise iam_e.CanNotResetUserPassword(
+                uuid=resource.uuid,
+                rule=c.PERMISSION_USER_RESET_PASSWORD,
+            )
         new_secret = new_password or self._req.params.get("new_password")
         self.validate(new_secret)
         resource.reset_secret_by_code(
@@ -897,8 +903,14 @@ class ClientsController(controllers.BaseResourceControllerPaginated, EnforceMixi
     def userinfo(self, resource):
         return resource.userinfo().get_response_body()
 
+    @oa_utils.extend_schema(**oa_specs.OA_SPEC_SEND_RESET_PASSWORD_CODE)
     @actions.post
-    def reset_password(self, resource, email=None):
+    def send_reset_password_code(self, resource, email=None):
+        if not self.enforce(c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE):
+            raise iam_e.CanNotSendResetPasswordCode(
+                uuid=resource.uuid,
+                rule=c.PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE,
+            )
         email = email or self._req.params.get("email")
         app_endpoint = _get_app_endpoint(req=self._req)
         resource.send_reset_password_event(email=email, app_endpoint=app_endpoint)

--- a/genesis_core/user_api/iam/api/openapi_specs.py
+++ b/genesis_core/user_api/iam/api/openapi_specs.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from restalchemy.api import constants as ra_c
 from restalchemy.openapi import constants as oa_c
 from genesis_core.user_api.iam import constants as c
 
@@ -98,6 +99,80 @@ responses.update(
     )
 )
 
+
+OA_SPEC_SEND_RESET_PASSWORD_CODE = dict(
+    summary="Send password reset code to email",
+    parameters=[
+        oa_c.build_openapi_parameter(
+            name="IamClientUuid",
+            openapi_type="string",
+            param_type="path",
+            required=True,
+        ),
+    ],
+    request_body=oa_c.build_openapi_req_body(
+        description="Trigger a password reset email for the specified user",
+        content_type=ra_c.CONTENT_TYPE_APPLICATION_JSON,
+        schema={
+            "type": "object",
+            "required": ["email"],
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email address of the user to send the reset link to",
+                    "example": "user@example.com",
+                },
+            },
+        },
+    ),
+    responses=oa_c.build_openapi_object_response(
+        properties={},
+        description="Password reset email sent successfully. No content returned.",
+    ),
+)
+
+OA_SPEC_RESET_PASSWORD_USER = dict(
+    summary="Reset user password",
+    parameters=[
+        oa_c.build_openapi_parameter(
+            name="UserUuid",
+            openapi_type="string",
+            param_type="path",
+            required=True,
+        ),
+    ],
+    request_body=oa_c.build_openapi_req_body(
+        description=(
+            "New password and optional confirmation code. "
+            "Either a valid reset code (from email) or the "
+            "`iam.user.reset_password` permission is required."
+        ),
+        content_type=ra_c.CONTENT_TYPE_APPLICATION_JSON,
+        schema={
+            "type": "object",
+            "required": ["new_password"],
+            "properties": {
+                "new_password": {
+                    "type": "string",
+                    "description": "New password for the user",
+                    "example": "MyNewP@ssw0rd",
+                },
+                "code": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": (
+                        "Confirmation code received via email. "
+                        "Required when caller does not have "
+                        "`iam.user.reset_password` permission."
+                    ),
+                    "example": "550e8400-e29b-41d4-a716-446655440000",
+                },
+            },
+        },
+    ),
+    responses=oa_c.build_openapi_get_update_response("User"),
+)
 
 OA_SPEC_GET_TOKEN_KWARGS = dict(
     summary="Create token by password",

--- a/genesis_core/user_api/iam/api/routes.py
+++ b/genesis_core/user_api/iam/api/routes.py
@@ -222,8 +222,8 @@ class MeAction(routes.Action):
     __controller__ = controllers.ClientsController
 
 
-class ResetPasswordEventAction(routes.Action):
-    """Handler for .../<uuid>/actions/reset_password/invoke endpoint"""
+class SendResetPasswordCodeAction(routes.Action):
+    """Handler for .../<uuid>/actions/send_reset_password_code/invoke endpoint"""
 
     __controller__ = controllers.ClientsController
 
@@ -258,7 +258,10 @@ class IamClientsRoute(routes.Route):
     me = routes.action(MeAction)
     userinfo = routes.action(UserinfoAction)
     logout = routes.action(LogoutAction, invoke=True)
-    reset_password = routes.action(ResetPasswordEventAction, invoke=True)
+    send_reset_password_code = routes.action(
+        SendResetPasswordCodeAction,
+        invoke=True,
+    )
     jwks = routes.action(JwksAction)
 
 

--- a/genesis_core/user_api/iam/constants.py
+++ b/genesis_core/user_api/iam/constants.py
@@ -128,6 +128,9 @@ PERMISSION_USER_DELETE_ALL = rules.Rule.from_raw(
 PERMISSION_USER_DELETE = rules.Rule.from_raw(
     "iam.user.delete",
 )
+PERMISSION_USER_RESET_PASSWORD = rules.Rule.from_raw(
+    "iam.user.reset_password",
+)
 
 
 # Organizations
@@ -241,6 +244,9 @@ PERMISSION_IAM_CLIENT_UPDATE = rules.Rule.from_raw(
 )
 PERMISSION_IAM_CLIENT_DELETE = rules.Rule.from_raw(
     "iam.iam_client.delete",
+)
+PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE = rules.Rule.from_raw(
+    "iam.iam_client.send_reset_password_code",
 )
 
 

--- a/genesis_core/user_api/iam/exceptions.py
+++ b/genesis_core/user_api/iam/exceptions.py
@@ -171,6 +171,28 @@ class CanNotDeleteIamClient(
     )
 
 
+class CanNotSendResetPasswordCode(
+    exceptions.CommonForbiddenException,
+    iam_exc.Forbidden,
+):
+    __template__ = (
+        "The current user is not permitted to send a reset password code"
+        " for IAM client `{uuid}`. This action requires the `{rule}`,"
+        " which has not been granted."
+    )
+
+
+class CanNotResetUserPassword(
+    exceptions.CommonForbiddenException,
+    iam_exc.Forbidden,
+):
+    __template__ = (
+        "Password reset failed for user `{uuid}`: a valid reset code or the"
+        " `{rule}` permission is required. Please use the reset link sent to"
+        " your email or contact your administrator."
+    )
+
+
 class CanNotCreateIdp(exceptions.CommonForbiddenException, iam_exc.Forbidden):
     __template__ = (
         "The current user is not permitted to create an IDP `{name}`."


### PR DESCRIPTION
- Add PERMISSION_USER_RESET_PASSWORD (iam.user.reset_password) and PERMISSION_IAM_CLIENT_SEND_RESET_PASSWORD_CODE (iam.iam_client.send_reset_password_code) constants
- Add CanNotResetUserPassword and CanNotSendResetPasswordCode exceptions
- UserController.reset_password: allow if reset code provided OR iam.user.reset_password permission granted; raise descriptive error if neither is present
- ClientsController: rename reset_password -> send_reset_password_code, enforce iam.iam_client.send_reset_password_code permission
- Add OA_SPEC_RESET_PASSWORD_USER and OA_SPEC_SEND_RESET_PASSWORD_CODE OpenAPI specs with extend_schema decorators on both methods
- Update routes.py: ResetPasswordEventAction -> SendResetPasswordCodeAction, register send_reset_password_code action in IamClientsRoute