### PR TITLE
Introduce GrantPermissionAction Rule + Use always for systemd services

### DIFF
--- a/etc/systemd/ec-boot-api.service
+++ b/etc/systemd/ec-boot-api.service
@@ -4,10 +4,9 @@ After=network-online.target
 
 [Service]
 TimeoutStopSec=5
-Restart=on-failure
+Restart=always
 RestartSec=5s
 KillSignal=SIGINT
-ExecStartPre=/bin/sleep 2
 ExecStart=ec-boot-api --config-file /etc/exordos_core/exordos_core.conf
 
 [Install]

--- a/etc/systemd/ec-core-agent.service
+++ b/etc/systemd/ec-core-agent.service
@@ -3,7 +3,7 @@ Description=Exordos Core Agent Service
 After=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=always
 RestartSec=5s
 TimeoutStopSec=5
 ExecStart=exordos-universal-agent-db-back --config-file /etc/exordos_core/core_agent.conf

--- a/etc/systemd/ec-gservice.service
+++ b/etc/systemd/ec-gservice.service
@@ -3,7 +3,7 @@ Description=Exordos Core General Service
 After=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=always
 RestartSec=5s
 TimeoutStopSec=5
 ExecStart=ec-gservice --config-file /etc/exordos_core/exordos_core.conf

--- a/etc/systemd/ec-orch-api.service
+++ b/etc/systemd/ec-orch-api.service
@@ -4,10 +4,9 @@ After=network-online.target
 
 [Service]
 TimeoutStopSec=5
-Restart=on-failure
+Restart=always
 RestartSec=5s
 KillSignal=SIGINT
-ExecStartPre=/bin/sleep 2
 ExecStart=ec-orch-api --config-file /etc/exordos_core/exordos_core.conf
 
 [Install]

--- a/etc/systemd/ec-status-api.service
+++ b/etc/systemd/ec-status-api.service
@@ -4,10 +4,9 @@ After=network-online.target
 
 [Service]
 TimeoutStopSec=5
-Restart=on-failure
+Restart=always
 RestartSec=5s
 KillSignal=SIGINT
-ExecStartPre=/bin/sleep 2
 ExecStart=ec-status-api --config-file /etc/exordos_core/exordos_core.conf
 
 [Install]

--- a/etc/systemd/ec-user-api.service
+++ b/etc/systemd/ec-user-api.service
@@ -4,10 +4,9 @@ After=network-online.target
 
 [Service]
 TimeoutStopSec=5
-Restart=on-failure
+Restart=always
 RestartSec=5s
 KillSignal=SIGINT
-ExecStartPre=/bin/sleep 2
 ExecStart=ec-user-api --config-file /etc/exordos_core/exordos_core.conf
 
 [Install]

--- a/etc/systemd/exordos-universal-agent.service
+++ b/etc/systemd/exordos-universal-agent.service
@@ -3,7 +3,7 @@ Description=Exordos Universal Agent Service
 After=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=always
 RestartSec=5s
 TimeoutStopSec=5
 ExecStart=exordos-universal-agent --config-file /etc/exordos_universal_agent/exordos_universal_agent.conf

--- a/etc/systemd/exordos-universal-scheduler.service
+++ b/etc/systemd/exordos-universal-scheduler.service
@@ -3,7 +3,7 @@ Description=Exordos Universal Scheduler Service
 After=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=always
 RestartSec=5s
 TimeoutStopSec=5
 ExecStart=exordos-universal-scheduler --config-file /etc/exordos_universal_agent/exordos_universal_agent.conf

--- a/exordos_core/common/contexts.py
+++ b/exordos_core/common/contexts.py
@@ -26,9 +26,30 @@ _RAW_PAYLOAD_MISSING = object()
 
 
 class GenesisCoreAuthContext(iam_contexts.GenesisCoreAuthContext):
+    """Custom auth context with security rules support."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._raw_payload_cache = _RAW_PAYLOAD_MISSING
+
+    def add_granted_permission(self, permission: str) -> None:
+        """Record a permission granted by a GrantPermissionAction Rule.
+
+        This is called by Rule.verify() when a GrantPermissionAction
+        successfully matches, recording the permission so that enforce()
+        can check it later.
+        """
+        if not hasattr(self.request, "environ"):
+            return
+        granted = self.request.environ.setdefault("_granted_permissions", set())
+        granted.add(permission)
+
+    def has_granted_permission(self, permission: str) -> bool:
+        """Check if a specific permission was granted by a Rule."""
+        if not hasattr(self.request, "environ"):
+            return False
+        granted = self.request.environ.get("_granted_permissions", set())
+        return permission in granted
 
     def get_user_ip(self) -> tp.Optional[netaddr.IPAddress]:
         request = self.request

--- a/exordos_core/common/contexts.py
+++ b/exordos_core/common/contexts.py
@@ -35,7 +35,7 @@ class GenesisCoreAuthContext(iam_contexts.GenesisCoreAuthContext):
     def add_granted_permission(self, permission: str) -> None:
         """Record a permission granted by a GrantPermissionAction Rule.
 
-        This is called by Rule.verify() when a GrantPermissionAction
+        This is called by Rule.execute() when a GrantPermissionAction
         successfully matches, recording the permission so that enforce()
         can check it later.
         """

--- a/exordos_core/tests/functional/restapi/iam/test_security_rules.py
+++ b/exordos_core/tests/functional/restapi/iam/test_security_rules.py
@@ -32,7 +32,7 @@ class TestSecurityRules:
                 uri=f"/v1/iam/users/{user_uuid}",
                 method="PUT",
             ),
-            verifier=security_models.FieldNotInRequestVerifier(
+            action=security_models.FieldNotInRequestVerifier(
                 fields=["email"],
             ),
             operator=security_models.OperatorEnum.AND.value,
@@ -49,7 +49,7 @@ class TestSecurityRules:
                 uri=f"/v1/iam/users/{user_uuid}",
                 method="PUT",
             ),
-            verifier=security_models.FieldNotInRequestVerifier(
+            action=security_models.FieldNotInRequestVerifier(
                 fields=fields,
             ),
             operator=security_models.OperatorEnum.OR.value,
@@ -65,7 +65,7 @@ class TestSecurityRules:
                 uri=f"/v1/iam/users/{user_uuid}",
                 method="PUT",
             ),
-            verifier=security_models.FieldNotInRequestVerifier(
+            action=security_models.FieldNotInRequestVerifier(
                 fields=["email"],
             ),
             operator=security_models.OperatorEnum.OR.value,
@@ -81,7 +81,7 @@ class TestSecurityRules:
                 "uri": f"/v1/iam/users/{user_uuid}",
                 "method": "PUT",
             },
-            "verifier": {
+            "action": {
                 "kind": "no_fields",
                 "fields": ["email"],
             },

--- a/exordos_core/tests/functional/restapi/iam/test_user_creation_security.py
+++ b/exordos_core/tests/functional/restapi/iam/test_user_creation_security.py
@@ -81,6 +81,16 @@ class TestUserCreationSecurity(base.BaseIamResourceTest):
             project_id=project_id,
         )
 
+    def _create_grant_permission_rule(self, permission, project_id=None):
+        verifier = security_models.GrantPermissionAction(
+            permission=permission,
+        )
+        return self._create_rule(
+            name="Grant permission for user creation",
+            verifier=verifier,
+            project_id=project_id,
+        )
+
     def _user_create_url(self, user_api):
         return urljoin(user_api.base_url, CREATE_USER_PATH)
 
@@ -193,3 +203,120 @@ class TestUserCreationSecurity(base.BaseIamResourceTest):
             user_api, headers, username_suffix="forbidden"
         )
         assert response.status_code == 403
+
+    def test_grant_permission_verifier_matches_all(
+        self,
+    ):
+        """GrantPermissionAction returns True for ALL requests."""
+        from unittest import mock
+
+        verifier = security_models.GrantPermissionAction(
+            permission="iam.user.create",
+        )
+
+        # Test with NoIamSessionStored (no auth at all)
+        ctx1 = mock.MagicMock()
+        assert verifier.verify(ctx1) is True
+
+        # Test with anonymous token (type='anon')
+        ctx2 = mock.MagicMock()
+        assert verifier.verify(ctx2) is True
+
+        # Test with authenticated user (type='user')
+        ctx3 = mock.MagicMock()
+        assert verifier.verify(ctx3) is True
+
+    def test_granted_permission_tracking_api(
+        self,
+    ):
+        """Test granted permission tracking API."""
+        from exordos_core.common import contexts
+
+        # Create mock request with environ
+        mock_request = mock.MagicMock()
+        mock_request.environ = {}
+
+        # Create context with mock request
+        ctx = mock.MagicMock(spec=contexts.GenesisCoreAuthContext)
+        ctx.request = mock_request
+
+        # Bind real methods to mock
+        ctx.add_granted_permission = (
+            contexts.GenesisCoreAuthContext.add_granted_permission.__get__(ctx)
+        )
+        ctx.has_granted_permission = (
+            contexts.GenesisCoreAuthContext.has_granted_permission.__get__(ctx)
+        )
+
+        # Initially no permission granted
+        assert ctx.has_granted_permission("iam.user.create") is False
+
+        # Grant a permission
+        ctx.add_granted_permission("iam.user.create")
+
+        # Now it is granted
+        assert ctx.has_granted_permission("iam.user.create") is True
+
+        # Other permissions are still not granted
+        assert ctx.has_granted_permission("iam.user.delete") is False
+
+    def test_create_user_anonymous_registration(
+        self,
+        user_api,
+    ):
+        """Anonymous user can register when GrantPermissionAction grants iam.user.create."""
+        # Grant permission rule - no Firebase, no CAPTCHA needed
+        self._create_grant_permission_rule(permission="iam.user.create")
+
+        # No Authorization header - completely anonymous request
+        response = self._post_create_user(
+            user_api, headers={}, username_suffix="street_user"
+        )
+        assert response.status_code in (200, 201), (
+            f"Anonymous registration failed: {response.status_code} - {response.text[:200]}"
+        )
+
+        # Verify user was created
+        data = response.json()
+        assert "uuid" in data
+        assert data["username"] == "testuser_street_user"
+
+    def test_create_user_anonymous_without_rule_is_forbidden(
+        self,
+        user_api,
+    ):
+        """Anonymous user cannot register without GrantPermissionAction Rule."""
+        # No rules created at all - only default admin rules exist
+
+        # No Authorization header - completely anonymous request
+        response = self._post_create_user(
+            user_api, headers={}, username_suffix="no_rule_user"
+        )
+        # Should be forbidden because no Rule allows anonymous access
+        # AND user doesn't have iam.user.create permission
+        assert response.status_code == 403
+
+    def test_authenticated_user_with_grant_permission_rule(
+        self,
+        user_api,
+        auth_test1_user,
+    ):
+        """Authenticated user CAN register when GrantPermissionAction Rule grants the permission.
+
+        The Rule grants iam.user.create permission for any request that
+        passes the security Rule, regardless of whether the user is
+        anonymous or authenticated.
+        """
+        self._create_grant_permission_rule(permission="iam.user.create")
+
+        token = self._get_access_token(user_api, auth_test1_user)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Authenticated request with GrantPermissionAction Rule
+        response = self._post_create_user(
+            user_api, headers=headers, username_suffix="auth_with_rule"
+        )
+        # Should succeed because Rule grants the required permission
+        assert response.status_code in (200, 201), (
+            f"Auth user with Rule failed: {response.status_code} - {response.text[:200]}"
+        )

--- a/exordos_core/tests/functional/restapi/iam/test_user_creation_security.py
+++ b/exordos_core/tests/functional/restapi/iam/test_user_creation_security.py
@@ -12,7 +12,7 @@ from exordos_core.user_api.security.dm import models as security_models
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (3, 9),
-    reason="altcha 0.2.x in security verifiers require Python 3.9+",
+    reason="altcha 0.2.x in security actions require Python 3.9+",
 )
 
 CREATE_USER_PATH = "iam/users/"
@@ -24,7 +24,7 @@ class TestUserCreationSecurity(base.BaseIamResourceTest):
     def _create_rule(
         self,
         name: str,
-        verifier: security_models.AbstractVerifier,
+        action: security_models.AbstractVerifier,
         project_id=None,
     ) -> security_models.Rule:
         condition = security_models.UriRegexConditions(
@@ -34,7 +34,7 @@ class TestUserCreationSecurity(base.BaseIamResourceTest):
         rule = security_models.Rule(
             name=name,
             condition=condition,
-            verifier=verifier,
+            action=action,
             operator=security_models.OperatorEnum.OR.value,
             project_id=project_id,
         )
@@ -46,23 +46,23 @@ class TestUserCreationSecurity(base.BaseIamResourceTest):
         project_id=None,
         allowed_app_ids=None,
     ):
-        verifier = security_models.FirebaseAppCheckVerifier(
+        action = security_models.FirebaseAppCheckVerifier(
             credentials_path="/tmp/fake-firebase-credentials.json",
             allowed_app_ids=allowed_app_ids or [],
         )
         return self._create_rule(
             name="Firebase App Check for user creation",
-            verifier=verifier,
+            action=action,
             project_id=project_id,
         )
 
     def _create_captcha_rule(self, project_id=None):
-        verifier = security_models.CaptchaVerifier(
+        action = security_models.CaptchaVerifier(
             hmac_key="test-hmac-key-12345",
         )
         return self._create_rule(
             name="CAPTCHA for user creation",
-            verifier=verifier,
+            action=action,
             project_id=project_id,
         )
 
@@ -72,22 +72,22 @@ class TestUserCreationSecurity(base.BaseIamResourceTest):
         project_id=None,
     ):
         normalized = [str(v) for v in allowed_identifiers if v is not None]
-        verifier = security_models.AdminBypassVerifier(
+        action = security_models.AdminBypassVerifier(
             bypass_users=normalized,
         )
         return self._create_rule(
             name="Admin bypass for user creation",
-            verifier=verifier,
+            action=action,
             project_id=project_id,
         )
 
     def _create_grant_permission_rule(self, permission, project_id=None):
-        verifier = security_models.GrantPermissionAction(
+        action = security_models.GrantPermissionAction(
             permission=permission,
         )
         return self._create_rule(
             name="Grant permission for user creation",
-            verifier=verifier,
+            action=action,
             project_id=project_id,
         )
 
@@ -152,7 +152,7 @@ class TestUserCreationSecurity(base.BaseIamResourceTest):
             }
         )
 
-        # altcha is imported inside verifier, so patch its global function
+        # altcha is imported inside action, so patch its global function
         with mock.patch("altcha.verify_solution") as mock_verify_solution:
             mock_verify_solution.return_value = (True, None)
             headers = {
@@ -168,7 +168,7 @@ class TestUserCreationSecurity(base.BaseIamResourceTest):
             "Authorization": f"Bearer {admin_token}",
         }
         with mock.patch(
-            "exordos_core.user_api.security.dm.models.AdminBypassVerifier.verify",
+            "exordos_core.user_api.security.dm.models.AdminBypassVerifier.execute",
             return_value=True,
         ):
             response = self._post_create_user(
@@ -204,27 +204,27 @@ class TestUserCreationSecurity(base.BaseIamResourceTest):
         )
         assert response.status_code == 403
 
-    def test_grant_permission_verifier_matches_all(
+    def test_grant_permission_action_matches_all(
         self,
     ):
         """GrantPermissionAction returns True for ALL requests."""
         from unittest import mock
 
-        verifier = security_models.GrantPermissionAction(
+        action = security_models.GrantPermissionAction(
             permission="iam.user.create",
         )
 
         # Test with NoIamSessionStored (no auth at all)
         ctx1 = mock.MagicMock()
-        assert verifier.verify(ctx1) is True
+        assert action.execute(ctx1) is True
 
         # Test with anonymous token (type='anon')
         ctx2 = mock.MagicMock()
-        assert verifier.verify(ctx2) is True
+        assert action.execute(ctx2) is True
 
         # Test with authenticated user (type='user')
         ctx3 = mock.MagicMock()
-        assert verifier.verify(ctx3) is True
+        assert action.execute(ctx3) is True
 
     def test_granted_permission_tracking_api(
         self,

--- a/exordos_core/user_api/api/middlewares.py
+++ b/exordos_core/user_api/api/middlewares.py
@@ -76,11 +76,11 @@ class SecurityRulesMiddleware(ra_middlewares.Middleware):
         if not rules_context.available:
             return True
         if rules_context.and_rules and all(
-            rule.verify(context) for rule in rules_context.and_rules
+            rule.execute(context) for rule in rules_context.and_rules
         ):
             return True
         if rules_context.or_rules:
-            return any(rule.verify(context) for rule in rules_context.or_rules)
+            return any(rule.execute(context) for rule in rules_context.or_rules)
 
         return False
 

--- a/exordos_core/user_api/iam/api/controllers.py
+++ b/exordos_core/user_api/iam/api/controllers.py
@@ -50,8 +50,11 @@ LOG = logging.getLogger(__name__)
 
 class EnforceMixin:
     def enforce(self, rule, do_raise=False, exc=None):
-        iam = contexts.get_context().iam_context
-        return iam.enforcer.enforce(rule, do_raise, exc)
+        ctx = contexts.get_context()
+        # Check if the permission was granted by a GrantPermissionAction Rule
+        if ctx.has_granted_permission(str(rule)):
+            return True
+        return ctx.iam_context.enforcer.enforce(rule, do_raise, exc)
 
 
 class ValidationException(ra_e.RestAlchemyException):

--- a/exordos_core/user_api/security/dm/models.py
+++ b/exordos_core/user_api/security/dm/models.py
@@ -105,7 +105,7 @@ class UriRegexConditions(AbstractConditions):
 
 class AbstractVerifier(ra_types_dynamic.AbstractKindModel):
     @abc.abstractmethod
-    def verify(self, context):
+    def execute(self, context):
         raise NotImplementedError()
 
 
@@ -117,7 +117,7 @@ class FieldNotInRequestVerifier(AbstractVerifier):
         required=True,
     )
 
-    def verify(self, context):
+    def execute(self, context):
         payload = context.get_raw_payload()
         if not isinstance(payload, dict):
             return True
@@ -153,14 +153,14 @@ class FirebaseAppCheckVerifier(AbstractVerifier):
         return None
 
     def _get_firebase_app(self):
-        """Return initialised default Firebase app, same semantics as original verifier."""
+        """Return initialised default Firebase app, same semantics as original action."""
         try:
             return firebase_admin.get_app()
         except ValueError:
             cred = credentials.Certificate(self.credentials_path)
             return firebase_admin.initialize_app(cred)
 
-    def verify(self, context):
+    def execute(self, context):
         request = context.request
 
         token = self._get_token_from_headers(request)
@@ -202,7 +202,7 @@ class CaptchaVerifier(AbstractVerifier):
 
     CAPTCHA_HEADER = "X-Captcha"
 
-    def verify(self, context):
+    def execute(self, context):
         request = context.request
         captcha_header = request.headers.get(self.CAPTCHA_HEADER)
         if not captcha_header:
@@ -233,7 +233,7 @@ class AdminBypassVerifier(AbstractVerifier):
         default=list,
     )
 
-    def verify(self, context):
+    def execute(self, context):
         """Return True if current user is explicitly allowed to bypass."""
         # Introspection info may be missing for unauthenticated requests
         try:
@@ -261,10 +261,10 @@ class AdminBypassVerifier(AbstractVerifier):
 class GrantPermissionAction(AbstractVerifier):
     """Verifier that grants a specific IAM permission when the Rule matches.
 
-    This verifier enables "street" registration - allowing user creation
+    This action enables "street" registration - allowing user creation
     without explicit iam.user.create permission when this Rule is active.
-    It always returns True (the verifier itself is a pass-through), but
-    the Rule.verify() will record the granted permission in the context
+    It always returns True (the action itself is a pass-through), but
+    the Rule.execute() will record the granted permission in the context
     so that enforce() checks succeed for anonymous users.
     """
 
@@ -275,11 +275,11 @@ class GrantPermissionAction(AbstractVerifier):
         required=True,
     )
 
-    def verify(self, context):
+    def execute(self, context):
         """Return True for all requests.
 
-        The Rule.verify() will record the granted permission in the
-        context only when this verifier is part of a Rule that fully passes.
+        The Rule.execute() will record the granted permission in the
+        context only when this action is part of a Rule that fully passes.
         """
         return True
 
@@ -314,7 +314,7 @@ class Rule(
         ),
         required=True,
     )
-    verifier = properties.property(
+    action = properties.property(
         ra_types_dynamic.KindModelSelectorType(
             ra_types_dynamic.KindModelType(FieldNotInRequestVerifier),
             ra_types_dynamic.KindModelType(FirebaseAppCheckVerifier),
@@ -337,10 +337,10 @@ class Rule(
     def can_handle(self, context):
         return self.condition.can_handle(context)
 
-    def verify(self, context):
-        result = self.verifier.verify(context)
-        # If this Rule passed and uses GrantPermissionAction, record
+    def execute(self, context):
+        result = self.action.execute(context)
+        # This is called by Rule.execute() when a GrantPermissionAction, record
         # the granted permission so that enforce() can check it later
-        if result and isinstance(self.verifier, GrantPermissionAction):
-            context.add_granted_permission(self.verifier.permission)
+        if result and isinstance(self.action, GrantPermissionAction):
+            context.add_granted_permission(self.action.permission)
         return result

--- a/exordos_core/user_api/security/dm/models.py
+++ b/exordos_core/user_api/security/dm/models.py
@@ -258,6 +258,32 @@ class AdminBypassVerifier(AbstractVerifier):
         return False
 
 
+class GrantPermissionAction(AbstractVerifier):
+    """Verifier that grants a specific IAM permission when the Rule matches.
+
+    This verifier enables "street" registration - allowing user creation
+    without explicit iam.user.create permission when this Rule is active.
+    It always returns True (the verifier itself is a pass-through), but
+    the Rule.verify() will record the granted permission in the context
+    so that enforce() checks succeed for anonymous users.
+    """
+
+    KIND = "grant_permission"
+
+    permission = properties.property(
+        ra_types.String(),
+        required=True,
+    )
+
+    def verify(self, context):
+        """Return True for all requests.
+
+        The Rule.verify() will record the granted permission in the
+        context only when this verifier is part of a Rule that fully passes.
+        """
+        return True
+
+
 class OperatorEnum(str, enum.Enum):
     OR = "OR"
     AND = "AND"
@@ -294,6 +320,7 @@ class Rule(
             ra_types_dynamic.KindModelType(FirebaseAppCheckVerifier),
             ra_types_dynamic.KindModelType(CaptchaVerifier),
             ra_types_dynamic.KindModelType(AdminBypassVerifier),
+            ra_types_dynamic.KindModelType(GrantPermissionAction),
         ),
         required=True,
     )
@@ -311,4 +338,9 @@ class Rule(
         return self.condition.can_handle(context)
 
     def verify(self, context):
-        return self.verifier.verify(context)
+        result = self.verifier.verify(context)
+        # If this Rule passed and uses GrantPermissionAction, record
+        # the granted permission so that enforce() can check it later
+        if result and isinstance(self.verifier, GrantPermissionAction):
+            context.add_granted_permission(self.verifier.permission)
+        return result

--- a/migrations/0061-rename-rule-verifier-to-action-a3b4c5.py
+++ b/migrations/0061-rename-rule-verifier-to-action-a3b4c5.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import migrations
+
+
+class MigrationStep(migrations.AbstractMigrationStep):
+    def __init__(self):
+        self._depends = [
+            "0060-openapi-spec_e-m-link-02ef0a.py",
+        ]
+
+    @property
+    def migration_id(self):
+        return "a3b4c5d6-7e8f-4a9b-8c0d-1e2f3a4b5c6d"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        expressions = [
+            """
+                ALTER TABLE "security_rules"
+                RENAME COLUMN "verifier" TO "action";
+            """,
+        ]
+
+        for expression in expressions:
+            session.execute(expression)
+
+    def downgrade(self, session):
+        expressions = [
+            """
+                ALTER TABLE "security_rules"
+                RENAME COLUMN "action" TO "verifier";
+            """,
+        ]
+
+        for expression in expressions:
+            session.execute(expression)
+
+
+migration_step = MigrationStep()


### PR DESCRIPTION
Request example:

```
curl --location 'http://10.20.0.2:11010/v1/security/rules/' \
--header 'Content-Type: application/json' \
--header "Authorization: Bearer $token" \
--data '{
    "name": "Allow anon",
    "condition": {
        "kind": "uri_regex",
        "uri_regex": "^/v1/iam/users/$",
        "method": "POST"
    },
    "action": {
        "kind": "grant_permission",
        "permission": "iam.user.create"
    },
    "operator": "AND"
}'
```