### PR TITLE
Skip core machine recreation during image update

### DIFF
--- a/exordos/manifests/core.yaml.j2
+++ b/exordos/manifests/core.yaml.j2
@@ -120,7 +120,7 @@ resources:
         kind: "disks"
         disks:
           - size: 10
-            image: "{{ repository }}/exordos_core/{{ version }}/exordos_core.raw.gz"
+            image: "{{ repository | default('https://repository.genesis-core.tech/exordos-elements') }}/core/{{ version }}/images/exordos-core.raw.gz"
           - size: 10
             label: data
 

--- a/exordos_core/cmd/bootstrap.py
+++ b/exordos_core/cmd/bootstrap.py
@@ -284,7 +284,7 @@ def _install_element_manifest(
         return
 
     os.system(
-        f"exordos --config {GCTL_CFG_DIR}/exordosctl.yaml elements install {manifest_path}"
+        f"exordos --config {GCTL_CFG_DIR}/exordosctl.yaml ee install {manifest_path}"
     )
 
 

--- a/exordos_core/compute/agents/universal/drivers/pool.py
+++ b/exordos_core/compute/agents/universal/drivers/pool.py
@@ -458,6 +458,17 @@ class MetaMachine(meta.MetaCoordinatorDataPlaneModel):
     project_id = properties.property(types.UUID(), required=True, read_only=True)
     port_info = properties.property(types.Dict(), default=dict)
 
+    @property
+    def _is_core_machine(self) -> bool:
+        """Determine if the machine belongs to the core set."""
+        # NOTE(akremenetsky): We don't have any metadata information in
+        # nodes/machines except the name and description. So the first
+        # implementation is pretty straightforward and just checks the
+        # machine name. In the future versions we need to associate metadata
+        # to the machine and keep this info there.
+        core_machine_name_prefix = "core-set-node"
+        return self.name.startswith(core_machine_name_prefix)
+
     def _port(self) -> models.Port:
         ipv4 = (
             netaddr.IPAddress(self.port_info["ipv4"])
@@ -518,6 +529,11 @@ class MetaMachine(meta.MetaCoordinatorDataPlaneModel):
 
             # TODO(akremenetsky): Support multiple interfaces
             break
+
+        # Ignore the image of core machines to perform update procedure via
+        # the guest machine driver and SeedOS in autonomous mode
+        if self._is_core_machine:
+            return
 
         # Don't try to restore image from legacy machine since it is not
         # available in the data plane. So to avoid recreation of such
@@ -730,14 +746,19 @@ class MetaMachine(meta.MetaCoordinatorDataPlaneModel):
         if dp_machine.image and self.image != dp_machine.image:
             unknown_action = False
 
-            # Recreate the machine, Seed OS flashes the new image
-            dp_machine.image = self.image
-            dp_machine.boot = self.boot
+            if not self._is_core_machine:
+                # Recreate the machine, Seed OS flashes the new image
+                dp_machine.image = self.image
+                dp_machine.boot = self.boot
 
-            # The node is going to be updated. The update process requires
-            # to switch the node into the boot network.
-            driver.recreate_machine(dp_machine, ports=(self._port(),))
-            LOG.info("The machine %s image updated.", self.uuid)
+                # The node is going to be updated. The update process requires
+                # to switch the node into the boot network.
+                driver.recreate_machine(dp_machine, ports=(self._port(),))
+                LOG.info("The machine %s image updated.", self.uuid)
+            else:
+                # TODO(akremenetsky): Update machine meta/description but don't recreate
+                # the machine.
+                pass
 
         # Boot (Finished update process)
         # Switching boot mode means the node finished the update process.

--- a/exordos_core/compute/builders/pool.py
+++ b/exordos_core/compute/builders/pool.py
@@ -76,9 +76,9 @@ class PoolBuilderService(sdk_builder.CollectionUniversalBuilderService):
     def _is_core_machine(self, machine: pool_models.Machine) -> bool:
         """Determine if the machine belongs to the core set."""
         # NOTE(akremenetsky): We don't have any metadata information in
-        # nodes/machines expect the name and description. So the first
-        # implementation it pretty straightforward and just check the
-        # machine name. In the future version we need to associate metadata
+        # nodes/machines except the name and description. So the first
+        # implementation is pretty straightforward and just checks the
+        # machine name. In the future versions we need to associate metadata
         # to the machine and keep this info there.
         core_machine_name_prefix = "core-set-node"
         return machine.name.startswith(core_machine_name_prefix)
@@ -267,14 +267,17 @@ class PoolBuilderService(sdk_builder.CollectionUniversalBuilderService):
                 # after the machine is flashed and switched to the main network.
                 port = models.Port.from_boot_network()
         else:
-            _, guest_actual = machine_guest_pair
-            # The image is changed, so the machine should be booted in the
-            # `network` boot mode and flashed with a new image.
-            if guest_actual and guest_actual.image != volume.image:
-                boot = nc.BootAlternative.network.value
-                # Any port for the boot network is fine. The port will be replaced
-                # after the machine is flashed and switched to the main network.
-                port = models.Port.from_boot_network()
+            # Don't swith boot mode for the core set as the update procedure
+            # is performed by guest machine driver.
+            if not self._is_core_machine(machine):
+                _, guest_actual = machine_guest_pair
+                # The image is changed, so the machine should be booted in the
+                # `network` boot mode and flashed with a new image.
+                if guest_actual and guest_actual.image != volume.image:
+                    boot = nc.BootAlternative.network.value
+                    # Any port for the boot network is fine. The port will be replaced
+                    # after the machine is flashed and switched to the main network.
+                    port = models.Port.from_boot_network()
 
         # Set correct boot value for the machine (root model)
         machine.boot = boot


### PR DESCRIPTION
Core set machines should not be recreated through the standard SeedOS network boot procedure. Instead, their update is handled separately by the guest machine driver.

- Add _is_core_machine helper to detect core-set nodes by name prefix
- Skip image restoration and machine recreation for core machines in the compute pool agent
- Skip boot mode switch for core machines in the pool builder
- Fix core disk image path in the bootstrap manifest