### PR TITLE
fix(compute/scheduler): preserve volume index in MachineVolume creation

### DIFF
--- a/exordos_core/compute/scheduler/service.py
+++ b/exordos_core/compute/scheduler/service.py
@@ -193,7 +193,7 @@ class SchedulerService(basic.BasicService):
         pool_volume = models.MachineVolume(
             uuid=volume.uuid,
             name=str(volume.uuid),
-            index=0,
+            index=volume.index,
             size=volume.size,
             image=volume.image,
             boot=volume.boot,


### PR DESCRIPTION
Fixes floating disk ordering bug where all MachineVolume objects got index=0 instead of the correct value from the source Volume. This ensures consistent disk device naming (vda, vdb, etc.) in VMs with multiple disks.

Closes https://github.com/exordos/exordos_core/issues/267