### PR TITLE
unique connection_uri

### DIFF
--- a/exordos_core/tests/functional/restapi/compute/test_hypervisor_api.py
+++ b/exordos_core/tests/functional/restapi/compute/test_hypervisor_api.py
@@ -221,3 +221,61 @@ class TestHypervisorUserApi:
 
         assert response.status_code == 200
         assert len(response.json()) == 1
+
+    def test_hypervisors_add_different_connection_uris(
+        self,
+        pool_factory: tp.Callable,
+        user_api_client: iam_clients.GenesisCoreTestRESTClient,
+        auth_user_admin: iam_clients.GenesisCoreAuth,
+    ):
+        client = user_api_client(auth_user_admin)
+        url = client.build_collection_uri(["compute", "hypervisors"])
+
+        hypervisor1 = pool_factory(
+            driver_spec={
+                "driver": "libvirt",
+                "connection_uri": "qemu+tcp://10.20.0.10/system",
+            },
+        )
+        hypervisor1.pop("status", None)
+        response = client.post(url, json=hypervisor1)
+        assert response.status_code == 201
+
+        hypervisor2 = pool_factory(
+            driver_spec={
+                "driver": "libvirt",
+                "connection_uri": "qemu+tcp://10.20.0.20/system",
+            },
+        )
+        hypervisor2.pop("status", None)
+        response = client.post(url, json=hypervisor2)
+        assert response.status_code == 201
+
+    def test_hypervisors_add_same_connection_uri(
+        self,
+        pool_factory: tp.Callable,
+        user_api_client: iam_clients.GenesisCoreTestRESTClient,
+        auth_user_admin: iam_clients.GenesisCoreAuth,
+    ):
+        client = user_api_client(auth_user_admin)
+        url = client.build_collection_uri(["compute", "hypervisors"])
+
+        hypervisor1 = pool_factory(
+            driver_spec={
+                "driver": "libvirt",
+                "connection_uri": "qemu+tcp://10.20.0.10/system",
+            },
+        )
+        hypervisor1.pop("status", None)
+        response = client.post(url, json=hypervisor1)
+        assert response.status_code == 201
+
+        hypervisor2 = pool_factory(
+            driver_spec={
+                "driver": "libvirt",
+                "connection_uri": "qemu+tcp://10.20.0.10/system",
+            },
+        )
+        hypervisor2.pop("status", None)
+        with pytest.raises(bazooka_exc.ConflictError):
+            client.post(url, json=hypervisor2)

--- a/migrations/0063-add-driver-spec-connection-uri-unique-index-a1b2c3.py
+++ b/migrations/0063-add-driver-spec-connection-uri-unique-index-a1b2c3.py
@@ -1,0 +1,59 @@
+# Copyright 2016 Eugene Frolov <eugene@frolov.net.ru>
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+
+from restalchemy.storage.sql import migrations
+
+LOG = logging.getLogger(__name__)
+
+
+class MigrationStep(migrations.AbstarctMigrationStep):
+    def __init__(self):
+        self._depends = ["0062-convert-varchar-to-jsonb-4d5e6f.py"]
+
+    @property
+    def migration_id(self):
+        return "eb26ecbc-ab9e-427d-af94-b11247589ec0"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        sql_expressions = [
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS machine_pools_driver_spec_connection_uri_idx
+            ON machine_pools ((driver_spec->>'connection_uri'));
+            """,
+        ]
+
+        for expr in sql_expressions:
+            session.execute(expr, None)
+
+    def downgrade(self, session):
+        sql_expressions = [
+            """
+            DROP INDEX IF EXISTS machine_pools_driver_spec_connection_uri_idx;
+            """,
+        ]
+
+        for expr in sql_expressions:
+            session.execute(expr, None)
+
+
+migration_step = MigrationStep()


### PR DESCRIPTION
10:45:12 user@user ~ → exordos c h u a5e0e30c-3f93-4dc7-88ea-195daea81ad7 --driver-spec connection_uri=qemu+tcp://10.20.0.1/system
Error: [409] {"type":"ConflictRecords","code":409,"message":"Duplicate parameters for '<MachinePool a5e0e30c-3f93-4dc7-88ea-195daea81ad7>'. Original message: duplicate key value violates unique constraint \"machine_pools_driver_spec_connection_uri_idx\"\nDETAIL:  Key ((driver_spec ->> 'connection_uri'::text))=(qemu+tcp://10.20.0.1/system) already exists."}