### PR TITLE
Fix docs sitemap site url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Exordos Core
-site_url: https://github.com/exordos/
+site_url: https://exordos.github.io/exordos_core/
 repo_name: exordos_core
 repo_url: https://github.com/exordos/exordos_core
 edit_uri: browse/docs/


### PR DESCRIPTION
## What changed

- Updated `site_url` in `mkdocs.yml` from `https://github.com/exordos/` to `https://exordos.github.io/exordos_core/`.

## Why

The public documentation sitemap generated `<loc>` entries under `https://github.com/exordos/...`, while the actual documentation pages are served from `https://exordos.github.io/exordos_core/...`. That made the sitemap misleading for search engines and weakened documentation indexing.

## Validation

- `uv tool run --with tox-uv tox -e docs-build`
- Verified `site/sitemap.xml`: generated URLs now point to `https://exordos.github.io/exordos_core/...`.