### PR TITLE
add: PoolAgentDriver entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ IamUserResetPassword = "exordos_core.events.payloads:ResetPasswordEventPayload"
 [project.entry-points."gcl_sdk_universal_agent"]
 PasswordCapabilityDriver = "exordos_core.agent.universal.drivers.secret.password:PasswordCapabilityDriver"
 CoreDNSCertificateCapabilityDriver = "exordos_core.agent.universal.drivers.secret.cert:CoreDNSCertificateCapabilityDriver"
+PoolAgentDriver = "exordos_core.compute.agents.universal.drivers.pool:PoolAgentDriver"
 
 [tool.uv]
 package = true


### PR DESCRIPTION
Update project configuration to register a new driver entry point. This change ensures that the PoolAgentDriver is correctly exposed and accessible within the SDK's universal agent framework.

### Highlights

* **Entrypoint Registration**: Added the PoolAgentDriver to the gcl_sdk_universal_agent entry points in pyproject.toml to facilitate its discovery.