### PR TITLE
fix(iam): hide registration_client from user API and /me response

### DIFF
--- a/exordos_core/tests/functional/restapi/iam/test_users.py
+++ b/exordos_core/tests/functional/restapi/iam/test_users.py
@@ -456,6 +456,34 @@ class TestUsers(base.BaseIamResourceTest):
             common_c.DEFAULT_CLIENT_UUID
         )
 
+    def test_create_user_rejects_caller_supplied_registration_client(
+        self, user_api_client, auth_user_admin
+    ):
+        client = user_api_client(
+            auth_user_admin,
+            permissions=[
+                iam_c.PERMISSION_USER_CREATE,
+            ],
+        )
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            client.create_user(
+                username="reg_client_spoof_user",
+                password="testtest",
+                registration_client=str(sys_uuid.uuid4()),
+            )
+
+    def test_update_user_rejects_caller_supplied_registration_client(
+        self, user_api_client, auth_test1_user
+    ):
+        client = user_api_client(auth_test1_user)
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            client.update_user(
+                auth_test1_user.uuid,
+                registration_client=str(sys_uuid.uuid4()),
+            )
+
     def _set_default_client_auto_provision(self, enabled):
         iam_client = iam_models.IamClient.objects.get_one(
             filters={"uuid": sys_uuid.UUID(common_c.DEFAULT_CLIENT_UUID)}
@@ -589,7 +617,6 @@ class TestUsers(base.BaseIamResourceTest):
             "email",
             "otp_enabled",
             "email_verified",
-            "registration_client",
             "type",
         ]
 

--- a/exordos_core/user_api/iam/api/controllers.py
+++ b/exordos_core/user_api/iam/api/controllers.py
@@ -162,6 +162,7 @@ class UserController(
                 "email": {
                     ra_c.UPDATE: iam_fp.Permissions.HIDDEN,
                 },
+                "registration_client": {ra_c.ALL: iam_fp.Permissions.HIDDEN},
             },
         ),
         name_map={"secret": "password", "name": "username"},

--- a/exordos_core/user_api/iam/dm/models.py
+++ b/exordos_core/user_api/iam/dm/models.py
@@ -914,6 +914,7 @@ class MeInfo:
             "confirmation_code_made_at",
             "user_source",
             "custom_props",
+            "registration_client",
         ]
         user = self._user.get_storable_snapshot()
         for drop_field in skip_fields:


### PR DESCRIPTION
registration_client is server-derived (set from the request's IAM client on create, never mutated on update) but the resource field permissions still defaulted it to read-write, so the public schema told callers they could set it even though the value was silently discarded. The /me endpoint bypassed field permissions entirely via its own hand-rolled snapshot serialization and leaked the field too.

Mark registration_client HIDDEN in UserController's field permissions so any attempt to set it via create/update is rejected, and add it to MeInfo's skip_fields so it no longer appears in /me responses either.

Addresses PR #443 review comment from cassi-volkova.