### PR TITLE
refactor(compute): migrate MachinePool driver_spec to KindModelSelect…

### DIFF
--- a/exordos_core/bootstrap/defaults.py
+++ b/exordos_core/bootstrap/defaults.py
@@ -402,10 +402,7 @@ def apply_startup_db(spec: dict[str, tp.Any]) -> None:
 
         # Skip if the pool already exists
         for _pool in machine_pools:
-            if (
-                _pool.driver_spec["connection_uri"]
-                == pool.driver_spec["connection_uri"]
-            ):
+            if _pool.driver_spec.connection_uri == pool.driver_spec.connection_uri:
                 break
         else:
             # Pool does not exist, create it

--- a/exordos_core/cmd/bootstrap.py
+++ b/exordos_core/cmd/bootstrap.py
@@ -30,7 +30,6 @@ import uuid as sys_uuid
 from oslo_config import cfg
 from restalchemy.common import config_opts as ra_config_opts
 from restalchemy.dm import filters as dm_filters
-from restalchemy.storage import exceptions as ra_exceptions
 from restalchemy.storage.sql import engines
 import yaml
 
@@ -175,50 +174,6 @@ def _apply_flat_network(stand: dict[str, tp.Any]) -> None:
         subnet.network = network.uuid
         subnet.insert()
         LOG.info("Created subnet %s", subnet.uuid)
-
-
-def _apply_startup_db(spec: dict[str, tp.Any]) -> None:
-    """Idempotent startup database configuration."""
-    stand = spec.get("stand", {})
-    if not stand:
-        LOG.info("No `stand` section found in %s", spec)
-        return
-
-    # Apply flat network configuration
-    _apply_flat_network(stand)
-
-    # Apply machine pools
-    # NOTE(akremenetsky): It maybe a problem for large installations
-    # with many machine pools, but it's fine for now.
-    machine_pools = models.MachinePool.objects.get_all()
-
-    for hypervisor in stand.get("hypervisors", []):
-        hypervisor["iface_mtu"] = 1500
-        pool_data = {
-            "name": "hypervisor",
-            "machine_type": "VM",
-            "driver_spec": hypervisor,
-        }
-        pool = models.MachinePool.restore_from_simple_view(**pool_data)
-
-        # Skip if the pool already exists
-        for _pool in machine_pools:
-            if (
-                _pool.driver_spec["connection_uri"]
-                == pool.driver_spec["connection_uri"]
-            ):
-                break
-        else:
-            # Pool does not exist, create it
-            try:
-                pool.insert()
-            except ra_exceptions.ConflictRecords:
-                LOG.info("Machine pool %s already exists", pool.uuid)
-            else:
-                LOG.info("Created machine pool %s", pool.uuid)
-            continue
-
-        LOG.info("Machine pool %s already exists, skipping", pool.uuid)
 
 
 def _ensure_exordos_config(spec: dict[str, tp.Any]):

--- a/exordos_core/compute/agents/universal/drivers/pool.py
+++ b/exordos_core/compute/agents/universal/drivers/pool.py
@@ -46,7 +46,14 @@ class MetaPool(meta.MetaCoordinatorDataPlaneModel):
 
     __driver_map__ = {}
 
-    driver_spec = properties.property(types.Dict(), required=True)
+    driver_spec = properties.property(
+        types_dynamic.KindModelSelectorType(
+            types_dynamic.KindModelType(models.LibvirtPoolDriverSpec),
+            types_dynamic.KindModelType(models.ExordosLocalHyperDriverSpec),
+            types_dynamic.KindModelType(models.DummyPoolDriverSpec),
+        ),
+        required=True,
+    )
     machine_type = properties.property(
         types.Enum([t.value for t in nc.NodeType]),
         default=nc.NodeType.VM.value,
@@ -88,8 +95,7 @@ class MetaPool(meta.MetaCoordinatorDataPlaneModel):
         if driver_key in self.__driver_map__:
             return self.__driver_map__[driver_key]
 
-        # TODO(akremenetsky): Use dynamic typing for this field
-        driver_kind = self.driver_spec["driver"]
+        driver_kind = self.driver_spec.KIND
 
         class_ = utils.load_from_entry_point(nc.EP_MACHINE_POOL_DRIVERS, driver_kind)
 
@@ -816,3 +822,9 @@ class PoolAgentDriver(meta.MetaCoordinatorAgentDriver):
             },
         },
     }
+
+
+class LocalPoolAgentDriver(PoolAgentDriver):
+    def get_capabilities(self) -> list[str]:
+        """Returns a list of capabilities supported by the driver."""
+        return super().get_capabilities() + ["local_pool"]

--- a/exordos_core/compute/dm/models.py
+++ b/exordos_core/compute/dm/models.py
@@ -102,6 +102,60 @@ class AbstractStoragePool(
         return self.available >= size
 
 
+class AbstractPoolDriverSpec(
+    types_dynamic.AbstractKindModel,
+    models.SimpleViewMixin,
+):
+    """Base class for all pool driver specs."""
+
+
+class LibvirtPoolDriverSpec(AbstractPoolDriverSpec):
+    KIND = "libvirt"
+
+    connection_uri = properties.property(
+        types.String(max_length=2048),
+        required=True,
+    )
+    network = properties.property(
+        types.AllowNone(types.String(max_length=255)),
+        default=None,
+    )
+    storage_pool = properties.property(
+        types.AllowNone(types.String(max_length=255)),
+        default=None,
+    )
+    machine_prefix = properties.property(
+        types.AllowNone(types.String(max_length=255)),
+        default=None,
+    )
+    network_type = properties.property(
+        types.Enum(["network", "bridge"]),
+        default="network",
+    )
+    iface_rom_file = properties.property(
+        types.AllowNone(types.String(max_length=255)),
+        default=None,
+    )
+    iface_mtu = properties.property(
+        types.Integer(min_value=0, max_value=65536),
+        default=1500,
+    )
+    iface_source = properties.property(
+        types.AllowNone(types.String(max_length=255)),
+        default=None,
+    )
+
+
+class ExordosLocalHyperDriverSpec(LibvirtPoolDriverSpec):
+    KIND = "exordos_local_hyper"
+
+    node = properties.property(types.UUID(), required=True)
+
+
+class DummyPoolDriverSpec(AbstractPoolDriverSpec):
+    KIND = "dummy"
+
+
 class ThinStoragePool(
     AbstractStoragePool,
     models.ModelWithNameDesc,
@@ -146,7 +200,14 @@ class MachinePool(
     __tablename__ = "machine_pools"
     __driver_map__ = {}
 
-    driver_spec = properties.property(types.Dict(), default=dict)
+    driver_spec = properties.property(
+        types_dynamic.KindModelSelectorType(
+            types_dynamic.KindModelType(LibvirtPoolDriverSpec),
+            types_dynamic.KindModelType(ExordosLocalHyperDriverSpec),
+            types_dynamic.KindModelType(DummyPoolDriverSpec),
+        ),
+        required=True,
+    )
     agent = properties.property(types.AllowNone(types.UUID()), default=None)
     builder = properties.property(types.AllowNone(types.UUID()), default=None)
     machine_type = properties.property(
@@ -173,26 +234,6 @@ class MachinePool(
         ),
         default=list,
     )
-
-    @property
-    def has_driver(self) -> bool:
-        return bool(self.driver_spec)
-
-    @classmethod
-    def default_hw_pool(cls) -> tp.Optional["MachinePool"]:
-        """Get the default pool for HW machines if exists.
-
-        The method returns the default pool if only a pool
-        with required parameters exists and there are not
-        other pools with similar parameters.
-        """
-        return cls.objects.get_one_or_none(
-            filters={
-                "machine_type": dm_filters.EQ(nc.NodeType.HW.value),
-                "driver_spec": dm_filters.EQ("{}"),
-                "status": dm_filters.EQ(nc.MachinePoolStatus.ACTIVE.value),
-            },
-        )
 
     def load_driver(self) -> tp.Type["AbstractPoolDriver"]:
         """

--- a/exordos_core/compute/pool/drivers/base.py
+++ b/exordos_core/compute/pool/drivers/base.py
@@ -143,16 +143,19 @@ class AbstractPoolDriver(abc.ABC):
 
 
 class DummyPoolDriver(AbstractPoolDriver):
-    SPEC = {"driver": "dummy"}
-
     def __init__(self, pool: models.MachinePool, dry_run: bool = False):
-        if pool.driver_spec != self.SPEC:
-            raise ValueError(f"Invalid driver spec: {pool.driver_spec}")
+        if pool.driver_spec is None or pool.driver_spec.KIND != "dummy":
+            raise ValueError(
+                f"Unsupported driver spec kind: "
+                f"{pool.driver_spec.KIND if pool.driver_spec else None!r}"
+            )
         super().__init__(dry_run=dry_run)
 
     def get_pool_info(self) -> models.MachinePool:
         """Get pool info."""
-        return models.MachinePool()
+        return models.MachinePool(
+            driver_spec=models.DummyPoolDriverSpec(),
+        )
 
     def list_pool_resources(
         self,
@@ -162,7 +165,13 @@ class DummyPoolDriver(AbstractPoolDriver):
         tp.Collection[models.MachineVolume],
     ]:
         """List pool resources."""
-        return models.MachinePool(), [], []
+        return (
+            models.MachinePool(
+                driver_spec=models.DummyPoolDriverSpec(),
+            ),
+            [],
+            [],
+        )
 
     def list_machines(
         self,

--- a/exordos_core/compute/pool/drivers/libvirt.py
+++ b/exordos_core/compute/pool/drivers/libvirt.py
@@ -529,20 +529,16 @@ class XMLLibvirtInstance(XMLLibvirtMixin):
         )
 
 
-class LibvirtPoolDriverSpec(tp.NamedTuple):
-    driver: tp.Literal["libvirt"]
-    network: str
-    storage_pool: str
-    connection_uri: str
-    machine_prefix: tp.Optional[str] = None
-    network_type: NetworkType = "network"
-    iface_rom_file: tp.Optional[str] = None
-    iface_mtu: int = 1450
-
-
 class LibvirtPoolDriver(base.AbstractPoolDriver):
     def __init__(self, pool: models.MachinePool, dry_run: bool = False):
-        self._spec = LibvirtPoolDriverSpec(**pool.driver_spec)
+        if pool.driver_spec is None or not isinstance(
+            pool.driver_spec, models.LibvirtPoolDriverSpec
+        ):
+            raise ValueError(
+                f"Unsupported driver spec kind: "
+                f"{pool.driver_spec.KIND if pool.driver_spec else None!r}"
+            )
+        self._spec = pool.driver_spec
         self._pool = pool
         # Check if connection string is valid and we can connect
         _ = self._client
@@ -860,6 +856,7 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
         """Get pool info."""
         info = self._client.getInfo()
         return models.MachinePool(
+            driver_spec=self._spec,
             all_cores=info[2],
             all_ram=info[1],
         )

--- a/exordos_core/compute/scheduler/service.py
+++ b/exordos_core/compute/scheduler/service.py
@@ -159,7 +159,6 @@ class SchedulerService(basic.BasicService):
                 "status": dm_filters.EQ(nc.MachinePoolStatus.ACTIVE.value),
                 "machine_type": dm_filters.EQ(nc.NodeType.VM.value),
                 "builder": dm_filters.IsNot(None),
-                "driver_spec": dm_filters.NE("{}"),
             },
             limit=limit,
         )
@@ -486,7 +485,33 @@ class SchedulerService(basic.BasicService):
 
         for pool in unsheduled:
             builder = random.choice(pool_builders)
-            agent = random.choice(machine_agents[MACHINE_POOL_CAP])
+
+            # TODO(akremenetsky): In the target architecture, pool scheduling
+            # should be done through filters and weighters, similar to node
+            # scheduling. For now, use a simple condition for specific kinds.
+            # For exordos_local_hyper pools, only schedule on local agents
+            # whose node matches the pool's driver_spec.node.
+            # For other pools, exclude local agents (with local_pool capability)
+            # since they are dedicated to local hypervisors.
+            all_agents = machine_agents[MACHINE_POOL_CAP]
+            if pool.driver_spec.KIND == "exordos_local_hyper":
+                available_agents = [
+                    a for a in all_agents if a.node == pool.driver_spec.node
+                ]
+            else:
+                available_agents = [
+                    a for a in all_agents if "local_pool" not in a.list_capabilities
+                ]
+
+            if not available_agents:
+                LOG.warning(
+                    "No suitable agents found to schedule pool %s (kind=%s)",
+                    pool.uuid,
+                    pool.driver_spec.KIND,
+                )
+                continue
+
+            agent = random.choice(available_agents)
 
             try:
                 pool.builder = builder.uuid

--- a/exordos_core/tests/functional/conftest.py
+++ b/exordos_core/tests/functional/conftest.py
@@ -559,7 +559,11 @@ def pool_factory():
         **kwargs,
     ) -> tp.Dict[str, tp.Any]:
         uuid = uuid or _make_uuid()
-        driver_spec = {"driver": "libvirt"} if driver_spec is None else driver_spec
+        driver_spec = (
+            {"kind": "libvirt", "connection_uri": "qemu+tcp://127.0.0.1/system"}
+            if driver_spec is None
+            else driver_spec
+        )
         status_value = nc.MachinePoolStatus.ACTIVE.value if status is None else status
         storage_pool = node_models.ThinStoragePool(
             pool_type="dummy",
@@ -569,9 +573,9 @@ def pool_factory():
             available_actual=1000,
         )
 
-        pool = node_models.MachinePool(
-            uuid=uuid,
-            agent=agent,
+        pool = node_models.MachinePool.restore_from_simple_view(
+            uuid=str(uuid),
+            agent=str(agent) if agent else None,
             name=name,
             status=status_value,
             driver_spec=driver_spec,
@@ -579,7 +583,7 @@ def pool_factory():
             avail_ram=avail_ram,
             all_cores=all_cores,
             all_ram=all_ram,
-            storage_pools=[storage_pool],
+            storage_pools=[storage_pool.dump_to_simple_view()],
             **kwargs,
         )
         view = pool.dump_to_simple_view()

--- a/exordos_core/tests/functional/restapi/compute/test_hypervisor_api.py
+++ b/exordos_core/tests/functional/restapi/compute/test_hypervisor_api.py
@@ -115,7 +115,7 @@ class TestHypervisorUserApi:
             hypervisor = pool_factory(
                 name=f"hypervisor_{i}",
                 driver_spec={
-                    "driver": "libvirt",
+                    "kind": "libvirt",
                     "connection_uri": f"qemu+tcp://10.20.0.{str(i + 1)}/system",
                 },
             )
@@ -217,7 +217,12 @@ class TestHypervisorUserApi:
 
         client = user_api_client(auth_test1_user)
 
-        hypervisor = pool_factory()
+        hypervisor = pool_factory(
+            driver_spec={
+                "kind": "libvirt",
+                "connection_uri": "qemu+tcp://10.20.0.2/system",
+            },
+        )
         hypervisor.pop("status", None)
         url = client.build_collection_uri(["compute", "hypervisors"])
 
@@ -252,7 +257,7 @@ class TestHypervisorUserApi:
 
         hypervisor1 = pool_factory(
             driver_spec={
-                "driver": "libvirt",
+                "kind": "libvirt",
                 "connection_uri": "qemu+tcp://10.20.0.10/system",
             },
         )
@@ -262,7 +267,7 @@ class TestHypervisorUserApi:
 
         hypervisor2 = pool_factory(
             driver_spec={
-                "driver": "libvirt",
+                "kind": "libvirt",
                 "connection_uri": "qemu+tcp://10.20.0.20/system",
             },
         )
@@ -286,7 +291,7 @@ class TestHypervisorUserApi:
 
         hypervisor1 = pool_factory(
             driver_spec={
-                "driver": "libvirt",
+                "kind": "libvirt",
                 "connection_uri": "qemu+tcp://10.20.0.10/system",
             },
         )
@@ -296,7 +301,7 @@ class TestHypervisorUserApi:
 
         hypervisor2 = pool_factory(
             driver_spec={
-                "driver": "libvirt",
+                "kind": "libvirt",
                 "connection_uri": "qemu+tcp://10.20.0.10/system",
             },
         )

--- a/exordos_core/tests/functional/service/test_scheduler.py
+++ b/exordos_core/tests/functional/service/test_scheduler.py
@@ -140,7 +140,13 @@ class TestSchedulerService:
         client.post(url, json=foo_pool)
 
         uuid_bar = sys_uuid.uuid4()
-        bar_pool = pool_factory(uuid=uuid_bar)
+        bar_pool = pool_factory(
+            uuid=uuid_bar,
+            driver_spec={
+                "kind": "libvirt",
+                "connection_uri": "qemu+tcp://10.20.0.2/system",
+            },
+        )
         url = client.build_collection_uri(["compute", "hypervisors"])
         client.post(url, json=bar_pool)
 
@@ -199,7 +205,13 @@ class TestSchedulerService:
         client.post(url, json=foo_pool)
 
         uuid_bar = sys_uuid.uuid4()
-        bar_pool = pool_factory(uuid=uuid_bar)
+        bar_pool = pool_factory(
+            uuid=uuid_bar,
+            driver_spec={
+                "kind": "libvirt",
+                "connection_uri": "qemu+tcp://10.20.0.2/system",
+            },
+        )
         url = client.build_collection_uri(["compute", "hypervisors"])
         client.post(url, json=bar_pool)
 

--- a/exordos_core/tests/manual/conftest.py
+++ b/exordos_core/tests/manual/conftest.py
@@ -511,7 +511,11 @@ def pool_factory():
         **kwargs,
     ) -> tp.Dict[str, tp.Any]:
         uuid = uuid or sys_uuid.uuid4()
-        driver_spec = {"driver": "libvirt"} if driver_spec is None else driver_spec
+        driver_spec = (
+            {"kind": "libvirt", "connection_uri": "qemu+tcp://127.0.0.1/system"}
+            if driver_spec is None
+            else driver_spec
+        )
         status_value = nc.MachinePoolStatus.ACTIVE.value if status is None else status
         storage_pool = node_models.ThinStoragePool(
             pool_type="dummy",
@@ -521,9 +525,9 @@ def pool_factory():
             available_actual=1000,
         )
 
-        pool = node_models.MachinePool(
-            uuid=uuid,
-            agent=agent,
+        pool = node_models.MachinePool.restore_from_simple_view(
+            uuid=str(uuid),
+            agent=str(agent) if agent else None,
             name=name,
             status=status_value,
             driver_spec=driver_spec,
@@ -531,7 +535,7 @@ def pool_factory():
             avail_ram=avail_ram,
             all_cores=all_cores,
             all_ram=all_ram,
-            storage_pools=[storage_pool],
+            storage_pools=[storage_pool.dump_to_simple_view()],
             **kwargs,
         )
         view = pool.dump_to_simple_view()

--- a/exordos_core/tests/unit/compute/test_scheduler_pool_scheduling.py
+++ b/exordos_core/tests/unit/compute/test_scheduler_pool_scheduling.py
@@ -1,0 +1,224 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import typing as tp
+from unittest import mock
+import uuid as sys_uuid
+
+import pytest
+
+from exordos_core.compute.dm import models
+from exordos_core.compute.scheduler import service
+
+_DEFAULT_LIBVIRT_SPEC = models.LibvirtPoolDriverSpec(
+    connection_uri="qemu+tcp://127.0.0.1/system",
+)
+
+
+def _make_local_hyper_spec(node: sys_uuid.UUID) -> models.ExordosLocalHyperDriverSpec:
+    return models.ExordosLocalHyperDriverSpec(
+        connection_uri="qemu+tcp://127.0.0.1/system",
+        node=node,
+    )
+
+
+def _make_agent(
+    uuid: sys_uuid.UUID,
+    node: tp.Optional[sys_uuid.UUID] = None,
+    capabilities: tp.Optional[list] = None,
+) -> mock.MagicMock:
+    agent = mock.MagicMock()
+    agent.uuid = uuid
+    agent.node = node
+    agent.list_capabilities = capabilities or ["pool"]
+    return agent
+
+
+class TestSchedulePoolsLocalHyper:
+    """Tests for pool scheduling with exordos_local_hyper kind."""
+
+    def setup_method(self) -> None:
+        self._service = service.SchedulerService(
+            pool_filters=[],
+            pool_weighters=[],
+            machine_filters=[],
+            machine_weighters=[],
+        )
+
+    def _make_pool(
+        self,
+        driver_spec: tp.Optional[models.AbstractPoolDriverSpec] = None,
+    ) -> mock.MagicMock:
+        pool = mock.MagicMock()
+        pool.uuid = sys_uuid.uuid4()
+        pool.driver_spec = driver_spec or _DEFAULT_LIBVIRT_SPEC
+        pool.builder = None
+        pool.agent = None
+        pool.update = mock.MagicMock()
+        return pool
+
+    @pytest.fixture
+    def builder(self):
+        builder = mock.MagicMock()
+        builder.uuid = sys_uuid.uuid4()
+        return builder
+
+    @pytest.fixture
+    def regular_agent(self):
+        return _make_agent(
+            uuid=sys_uuid.uuid4(),
+            node=sys_uuid.uuid4(),
+            capabilities=["pool"],
+        )
+
+    @pytest.fixture
+    def local_agent(self):
+        node = sys_uuid.uuid4()
+        return _make_agent(
+            uuid=sys_uuid.uuid4(),
+            node=node,
+            capabilities=["pool", "local_pool"],
+        )
+
+    @pytest.fixture
+    def local_pool(self, local_agent):
+        return self._make_pool(
+            driver_spec=_make_local_hyper_spec(local_agent.node),
+        )
+
+    @pytest.fixture
+    def regular_pool(self):
+        return self._make_pool(driver_spec=_DEFAULT_LIBVIRT_SPEC)
+
+    def test_local_pool_scheduled_on_matching_agent(
+        self,
+        builder,
+        local_agent,
+        regular_agent,
+        local_pool,
+    ):
+        """Local hyper pool should be scheduled on the agent with matching node."""
+        with (
+            mock.patch.object(
+                self._service, "_get_unscheduled_pools", return_value=[local_pool]
+            ),
+            mock.patch.object(
+                service.ua_models.UniversalAgent,
+                "have_capabilities",
+                return_value={"pool": [regular_agent, local_agent]},
+            ),
+        ):
+            self._service._schedule_pools([builder])
+
+        assert local_pool.agent == local_agent.uuid
+        assert local_pool.builder == builder.uuid
+        local_pool.update.assert_called_once()
+
+    def test_local_pool_not_scheduled_without_matching_agent(
+        self,
+        builder,
+        regular_agent,
+        local_pool,
+    ):
+        """Local hyper pool should not be scheduled if no agent with matching node."""
+        with (
+            mock.patch.object(
+                self._service, "_get_unscheduled_pools", return_value=[local_pool]
+            ),
+            mock.patch.object(
+                service.ua_models.UniversalAgent,
+                "have_capabilities",
+                return_value={"pool": [regular_agent]},
+            ),
+        ):
+            self._service._schedule_pools([builder])
+
+        assert local_pool.agent is None
+        local_pool.update.assert_not_called()
+
+    def test_regular_pool_excludes_local_agent(
+        self,
+        builder,
+        regular_agent,
+        local_agent,
+        regular_pool,
+    ):
+        """Regular pool should not be scheduled on a local agent."""
+        with (
+            mock.patch.object(
+                self._service, "_get_unscheduled_pools", return_value=[regular_pool]
+            ),
+            mock.patch.object(
+                service.ua_models.UniversalAgent,
+                "have_capabilities",
+                return_value={"pool": [regular_agent, local_agent]},
+            ),
+        ):
+            self._service._schedule_pools([builder])
+
+        assert regular_pool.agent == regular_agent.uuid
+        assert regular_pool.builder == builder.uuid
+        regular_pool.update.assert_called_once()
+
+    def test_regular_pool_not_scheduled_if_only_local_agents(
+        self,
+        builder,
+        local_agent,
+        regular_pool,
+    ):
+        """Regular pool should not be scheduled if only local agents available."""
+        with (
+            mock.patch.object(
+                self._service, "_get_unscheduled_pools", return_value=[regular_pool]
+            ),
+            mock.patch.object(
+                service.ua_models.UniversalAgent,
+                "have_capabilities",
+                return_value={"pool": [local_agent]},
+            ),
+        ):
+            self._service._schedule_pools([builder])
+
+        assert regular_pool.agent is None
+        regular_pool.update.assert_not_called()
+
+    def test_mixed_pools_scheduled_correctly(
+        self,
+        builder,
+        regular_agent,
+        local_agent,
+        regular_pool,
+        local_pool,
+    ):
+        """Both regular and local pools should be scheduled on correct agents."""
+        with (
+            mock.patch.object(
+                self._service,
+                "_get_unscheduled_pools",
+                return_value=[regular_pool, local_pool],
+            ),
+            mock.patch.object(
+                service.ua_models.UniversalAgent,
+                "have_capabilities",
+                return_value={"pool": [regular_agent, local_agent]},
+            ),
+        ):
+            self._service._schedule_pools([builder])
+
+        assert regular_pool.agent == regular_agent.uuid
+        assert local_pool.agent == local_agent.uuid
+        regular_pool.update.assert_called_once()
+        local_pool.update.assert_called_once()

--- a/exordos_core/tests/unit/compute/test_weighter.py
+++ b/exordos_core/tests/unit/compute/test_weighter.py
@@ -20,6 +20,10 @@ from exordos_core.compute.dm import models
 from exordos_core.compute.scheduler.driver import base
 from exordos_core.compute.scheduler.driver.weighter import relative
 
+_DEFAULT_DRIVER_SPEC = models.LibvirtPoolDriverSpec(
+    connection_uri="qemu+tcp://127.0.0.1/system",
+)
+
 
 class TestSchedulerWeighter:
     @pytest.fixture
@@ -32,6 +36,7 @@ class TestSchedulerWeighter:
             # 50% used
             base.MachinePoolBundle(
                 pool=models.MachinePool(
+                    driver_spec=_DEFAULT_DRIVER_SPEC,
                     all_cores=100,
                     avail_cores=50,
                     all_ram=100000,
@@ -42,6 +47,7 @@ class TestSchedulerWeighter:
             # 20% used
             base.MachinePoolBundle(
                 pool=models.MachinePool(
+                    driver_spec=_DEFAULT_DRIVER_SPEC,
                     all_cores=100,
                     avail_cores=80,
                     all_ram=100000,
@@ -52,7 +58,11 @@ class TestSchedulerWeighter:
             # Fully used
             base.MachinePoolBundle(
                 pool=models.MachinePool(
-                    all_cores=100, avail_cores=0, all_ram=100000, avail_ram=0
+                    driver_spec=_DEFAULT_DRIVER_SPEC,
+                    all_cores=100,
+                    avail_cores=0,
+                    all_ram=100000,
+                    avail_ram=0,
                 ),
                 volumes=[],
             ),
@@ -63,6 +73,7 @@ class TestSchedulerWeighter:
         empty_pools = [
             base.MachinePoolBundle(
                 pool=models.MachinePool(
+                    driver_spec=_DEFAULT_DRIVER_SPEC,
                     all_cores=100,
                     avail_cores=100,
                     all_ram=100000,
@@ -87,6 +98,7 @@ class TestSchedulerWeighter:
         overused_pools = [
             base.MachinePoolBundle(
                 pool=models.MachinePool(
+                    driver_spec=_DEFAULT_DRIVER_SPEC,
                     all_cores=100,
                     avail_cores=-10,
                     all_ram=100000,

--- a/exordos_core/user_api/compute/api/controllers.py
+++ b/exordos_core/user_api/compute/api/controllers.py
@@ -23,6 +23,7 @@ from restalchemy.api import controllers
 from restalchemy.api import field_permissions as field_p
 from restalchemy.api import resources
 from restalchemy.common import exceptions as ra_e
+from restalchemy.storage import exceptions as storage_exc
 
 from exordos_core.compute import constants as nc
 from exordos_core.compute.dm import models as models
@@ -200,4 +201,37 @@ class HypervisorsController(
         if "machine_type" in kwargs and kwargs["machine_type"] != nc.NodeType.VM.value:
             raise ValueError("Hyper must be VM type")
 
+        self._validate_driver_spec_uniqueness(kwargs)
+
         return super().create(**kwargs)
+
+    def _validate_driver_spec_uniqueness(self, kwargs: dict) -> None:
+        """Validate that the driver_spec fields are unique among existing pools."""
+        driver_spec = kwargs["driver_spec"]
+        kind = driver_spec["kind"]
+
+        if kind == models.LibvirtPoolDriverSpec.KIND:
+            connection_uri = driver_spec["connection_uri"]
+            # TODO(akremenetsky): Use JSON field filter when restalchemy
+            # supports filtering by JSONB fields.
+            existing_pools = models.MachinePool.objects.get_all()
+            for pool in existing_pools:
+                if (
+                    pool.driver_spec.KIND == kind
+                    and pool.driver_spec.connection_uri == connection_uri
+                ):
+                    raise storage_exc.ConflictRecords(
+                        model="MachinePool",
+                        msg=f"connection_uri={connection_uri}",
+                    )
+        elif kind == models.ExordosLocalHyperDriverSpec.KIND:
+            node = str(driver_spec["node"])
+            # TODO(akremenetsky): Use JSON field filter when restalchemy
+            # supports filtering by JSONB fields.
+            existing_pools = models.MachinePool.objects.get_all()
+            for pool in existing_pools:
+                if pool.driver_spec.KIND == kind and str(pool.driver_spec.node) == node:
+                    raise storage_exc.ConflictRecords(
+                        model="MachinePool",
+                        msg=f"node={node}",
+                    )

--- a/migrations/0066-machine-pools-driver-spec-kind-migration-138d02.py
+++ b/migrations/0066-machine-pools-driver-spec-kind-migration-138d02.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+
+from restalchemy.storage.sql import migrations
+
+LOG = logging.getLogger(__name__)
+
+
+class MigrationStep(migrations.AbstractMigrationStep):
+    def __init__(self):
+        self._depends = [
+            "0065-registration-client-auto-provision-b7f2d9.py",
+        ]
+
+    @property
+    def migration_id(self):
+        return "138d02f4-c3db-45cc-ba81-f3153c211731"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        # Rename "driver" key to "kind" in machine_pools.driver_spec JSONB
+        # column. Migrate empty '{}' specs to dummy spec since driver_spec
+        # is now a required field.
+        sql_expressions = [
+            """
+            UPDATE machine_pools
+            SET driver_spec = jsonb_set(
+                driver_spec - 'driver',
+                '{kind}',
+                driver_spec->'driver'
+            ),
+                updated_at = current_timestamp
+            WHERE driver_spec ? 'driver';
+            """,
+            """
+            ALTER TABLE machine_pools ALTER COLUMN driver_spec DROP DEFAULT;
+            """,
+            """
+            UPDATE machine_pools
+            SET driver_spec = '{"kind": "dummy"}'::jsonb,
+                updated_at = current_timestamp
+            WHERE driver_spec = '{}'::jsonb;
+            """,
+            # Drop the unique index on connection_uri since
+            # exordos_local_hyper pools may share the same connection_uri.
+            """
+            DROP INDEX IF EXISTS machine_pools_driver_spec_connection_uri_idx;
+            """,
+        ]
+
+        for expr in sql_expressions:
+            session.execute(expr, None)
+
+    def downgrade(self, session):
+        sql_expressions = [
+            """
+            UPDATE machine_pools
+            SET driver_spec = jsonb_set(
+                driver_spec - 'kind',
+                '{driver}',
+                driver_spec->'kind'
+            ),
+                updated_at = current_timestamp
+            WHERE driver_spec ? 'kind';
+            """,
+            """
+            ALTER TABLE machine_pools
+            ALTER COLUMN driver_spec SET DEFAULT '{}'::jsonb;
+            """,
+            """
+            UPDATE machine_pools
+            SET driver_spec = '{}'::jsonb,
+                updated_at = current_timestamp
+            WHERE driver_spec = '{"kind": "dummy"}'::jsonb;
+            """,
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS machine_pools_driver_spec_connection_uri_idx
+            ON machine_pools ((driver_spec->>'connection_uri'));
+            """,
+        ]
+
+        for expr in sql_expressions:
+            session.execute(expr, None)
+
+
+migration_step = MigrationStep()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ IamUserResetPassword = "exordos_core.events.payloads:ResetPasswordEventPayload"
 PasswordCapabilityDriver = "exordos_core.agent.universal.drivers.secret.password:PasswordCapabilityDriver"
 CoreDNSCertificateCapabilityDriver = "exordos_core.agent.universal.drivers.secret.cert:CoreDNSCertificateCapabilityDriver"
 PoolAgentDriver = "exordos_core.compute.agents.universal.drivers.pool:PoolAgentDriver"
+LocalPoolAgentDriver = "exordos_core.compute.agents.universal.drivers.pool:LocalPoolAgentDriver"
 
 [tool.uv]
 package = true


### PR DESCRIPTION
- Replace free-form dict driver_spec with discriminated union of LibvirtPoolDriverSpec and DummyPoolDriverSpec kind models
- Update LibvirtPoolDriver and DummyPoolDriver to use typed spec
- Update MetaPool in agent driver to use .KIND instead of dict access
- Fix bootstrap code to use attribute access for connection_uri
- Remove obsolete driver_spec filter in scheduler (now always required)
- Add migration to rename "driver" key to "kind" in existing data and update updated_at to propagate changes to data plane
- Update test fixtures and tests to use new "kind" format