### PR TITLE
migrate_to_persistent /etc/dnsdist

### DIFF
--- a/exordos/images/bootstrap.sh
+++ b/exordos/images/bootstrap.sh
@@ -76,6 +76,7 @@ if [[ -n "$PERSISTENT_DISK" ]]; then
     migrate_to_persistent "/var/lib/exordos/data" "${PERSISTENT_MOUNT}/var/lib/exordos/data"
     migrate_to_persistent_stop_start "/var/lib/postgresql" "${PERSISTENT_MOUNT}/var/lib/postgresql" "postgresql@${PG_VERSION}-main" "postgres" "postgres"
     migrate_to_persistent "/etc/exordos_core" "${PERSISTENT_MOUNT}/etc/exordos_core"
+    migrate_to_persistent "/etc/dnsdist" "${PERSISTENT_MOUNT}/etc/dnsdist"
     migrate_to_persistent "/home/ubuntu" "${PERSISTENT_MOUNT}/home/ubuntu"
     migrate_to_persistent "/root" "${PERSISTENT_MOUNT}/root"
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Include /etc/dnsdist in the set of directories migrated to the persistent mount during bootstrap to retain dnsdist configuration across restarts.