### PR TITLE
docs(usage): fix stale hypervisors init flag names in local deployment guide

### DIFF
--- a/docs/usage/local_deployment.md
+++ b/docs/usage/local_deployment.md
@@ -46,9 +46,9 @@ Run `exordos compute hypervisors init --help` to see all available options. The 
 
 | Option | Description |
 |---|---|
-| `--pool_name TEXT` | Name of the libvirt storage pool to use for VM disk images. Defaults to `default`. |
+| `--pool-name TEXT` | Name of the libvirt storage pool to use for VM disk images. Defaults to `default`. |
 | `--packer` / `-p` | Install HashiCorp Packer alongside the hypervisor setup. |
-| `--romfile_version TEXT` | Version of the network interface ROM file to install. |
+| `--romfile-version TEXT` | Version of the network interface ROM file to install. Defaults to `latest`. |
 
 ## Bootstrap
 

--- a/docs/usage/local_deployment.ru.md
+++ b/docs/usage/local_deployment.ru.md
@@ -46,9 +46,9 @@ exordos compute hypervisors init
 
 | Параметр | Описание |
 |---|---|
-| `--pool_name TEXT` | Имя пула хранилища libvirt для образов дисков виртуальных машин. По умолчанию: `default`. |
+| `--pool-name TEXT` | Имя пула хранилища libvirt для образов дисков виртуальных машин. По умолчанию: `default`. |
 | `--packer` / `-p` | Установить HashiCorp Packer вместе с настройкой гипервизора. |
-| `--romfile_version TEXT` | Версия ROM-файла сетевого интерфейса для установки. |
+| `--romfile-version TEXT` | Версия ROM-файла сетевого интерфейса для установки. По умолчанию: `latest`. |
 
 ## Bootstrap
 


### PR DESCRIPTION
--pool_name/--romfile_version never matched the actual CLI (--pool-name/ --romfile-version, click's usual dash convention) - fix in both the English and Russian guides, and note --romfile-version's actual default (latest).