### PR TITLE
fix(compute): register the dummy pool driver under its own kind

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ ec-bootstrap-templates = "exordos_core.cmd.bootstrap_templates:main"
 exordos-repo-proxy-gservice = "exordos_core.cmd.repo_proxy_gservice:main"
 
 [project.entry-points."gcn_machine_pool_driver"]
-DummyPoolDriver = "exordos_core.compute.pool.drivers.base:DummyPoolDriver"
+dummy = "exordos_core.compute.pool.drivers.base:DummyPoolDriver"
 libvirt = "exordos_core.compute.pool.drivers.libvirt:LibvirtPoolDriver"
 
 [project.entry-points."gcn_network_driver"]


### PR DESCRIPTION
The gcn_machine_pool_driver entry point was registered as "DummyPoolDriver" instead of "dummy", so it never matched DummyPoolDriverSpec.KIND and could never be loaded - unlike its "libvirt" sibling entry, which correctly used the driver spec's KIND as the entry point name.